### PR TITLE
feat: filter sync row by condition with `restrict_to` and `#[immutable]`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,26 +16,32 @@ macros (`syn`, `quote`)
 
 ```
 carburetor-rs/
-├── carburetor/                  # Runtime library
+├── carburetor/                            # Runtime library
 │   └── src/
-│       ├── helpers/             # Utility modules
-│       ├── config.rs            # Config singleton
-│       ├── error.rs             # Error types
-│       ├── models.rs            # DownloadTableResponse, sync models
+│       ├── helpers/                       # Utility modules
+│       ├── config.rs                      # Config singleton
+│       ├── error.rs                       # Error types
+│       ├── models.rs                      # DownloadTableResponse, sync models
 │       └── lib.rs
-├── carburetor-macro/            # Proc macro crate
+├── carburetor-macro/                      # Proc macro crate
 │   └── src/
-│       ├── parsers/             # Input parsing
-│       ├── generators/          # Code generation
-│       └── helpers/             # Shared macro utilities
+│       ├── parsers/                       # Input parsing
+│       ├── generators/                    # Code generation
+│       └── helpers/                       # Shared macro utilities
 ├── docs/
-│   └── features/
-│       └── basic-feature.md     # Core feature documentation
-├── examples/                    # Usage demos (simple-backend, simple-client)
+│   ├── features/                          # Feature related documentation
+│   │   ├── basic-feature.md               # Core feature documentation
+│   │   └── filter-row-by-condition.md     # Documentation about filtering sync by row condition (`restrict_to`, `restrict_to_column`)
+│   └── development/                       # Development related documentation
+│       └── e2e-testing.md                 # E2E testing documentation
+├── examples/                              # Usage demos (simple-backend, simple-client)
 └── tests/
-    ├── e2e-test/                # E2E test suite (client feature, tarpc RPC client)
-    ├── sample-test-backend/     # Standalone backend binary for E2E tests (tarpc RPC server)
-    └── sample-test-core/        # Shared schema crate (supports both backend/client features)
+    ├── e2e-test/tests/                    # E2E test suite (client feature, tarpc RPC client)
+    │   ├── edge_cases/                    # Designed scenarios to test correctness in the system on cases that happens on special conditions
+    │   ├── happy_paths/                   # Tests for system working under normal situations, modules under are categorize by processes
+    │   └── unhappy_paths/                 # Tests for ensuring that error are treated
+    ├── sample-test-backend/               # Standalone backend binary for E2E tests (tarpc RPC server)
+    └── sample-test-core/                  # Shared schema crate (supports both backend/client features)
 ```
 
 ## Module Details
@@ -150,9 +156,10 @@ key relationships might be temporarily broken during download.
 
 ### Testing
 
-- E2E tests use a tarpc RPC backend server + testcontainers PostgreSQL for isolated integration testing
-The shared SQLite singleton requires sequential test execution (`--test-threads=1`)
-- Examples serve as integration tests for end-to-end functionality
+- Use tests/e2e-test to design tests for new feature added
+- E2E tests use a tarpc RPC backend server + testcontainers PostgreSQL for
+  isolated integration testing The shared SQLite singleton requires sequential
+  test execution (`--test-threads=1`)
 
 ### Development Flow
 
@@ -163,5 +170,6 @@ When developing to add new features or resolve issues with the codebase:
 3. Note that both backend and client feature should individually compile and
    error free
 4. Utilize carburetor helpers to reduce code generation
-5. Update test case in `tests/e2e-test/`
+5. Update test case in `tests/e2e-test/`, the test created should follow the
+current folder structure
 6. Update documentation in `docs/features/`

--- a/carburetor-macro/src/generators/client/local_operations/functions.rs
+++ b/carburetor-macro/src/generators/client/local_operations/functions.rs
@@ -80,8 +80,8 @@ impl<'a> ToTokens for AsLocalUpdateFunction<'a> {
             .iter()
             .filter_map(|x| {
                 let column_name = &x.ident;
-                match x.column_type {
-                    CarburetorColumnType::Data => Some(quote! {
+                if x.column_type == CarburetorColumnType::Data && !x.is_immutable {
+                    Some(quote! {
                         if changeset.#column_name.is_some() {
                             new_metadata
                                 .data
@@ -90,8 +90,9 @@ impl<'a> ToTokens for AsLocalUpdateFunction<'a> {
                                 .get_or_insert_default()
                                 .dirty_at = Some(carburetor::helpers::get_utc_now());
                         }
-                    }),
-                    _ => None,
+                    })
+                } else {
+                    None
                 }
             })
             .collect::<Vec<_>>();
@@ -270,4 +271,3 @@ pub fn generate_local_operation_functions(
         tokens.extend(AsActiveTableFunction(x).to_token_stream());
     })
 }
-

--- a/carburetor-macro/src/generators/client/local_operations/models.rs
+++ b/carburetor-macro/src/generators/client/local_operations/models.rs
@@ -148,6 +148,7 @@ impl<'a> ToTokens for AsLocalUpdateModel<'a> {
                 })
             } else if x.column_type == CarburetorColumnType::Data
                 && x.mod_on_backend_only_config == BackendOnlyConfig::Disabled
+                && !x.is_immutable
             {
                 let field_name = &x.ident;
                 let field_type = AsModelType(&x.diesel_type);
@@ -196,9 +197,10 @@ impl<'a> ToTokens for AsLocalUpdateToChangeset<'a> {
                     &x.column_type,
                     &x.client_only_config,
                     &x.mod_on_backend_only_config,
+                    &x.is_immutable,
                 ) {
-                    (&CarburetorColumnType::Id, _, _)
-                    | (&CarburetorColumnType::Data, _, &BackendOnlyConfig::Disabled) => {
+                    (&CarburetorColumnType::Id, _, _, _)
+                    | (&CarburetorColumnType::Data, _, &BackendOnlyConfig::Disabled, false) => {
                         let field_name = &x.ident;
                         Some(quote! {
                             #field_name: value.#field_name

--- a/carburetor-macro/src/generators/context/mod.rs
+++ b/carburetor-macro/src/generators/context/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod models;

--- a/carburetor-macro/src/generators/context/models.rs
+++ b/carburetor-macro/src/generators/context/models.rs
@@ -1,0 +1,48 @@
+use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
+use syn::{Ident, Type, parse_str};
+
+use crate::parsers::sync_group::CarburetorSyncGroup;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AsSyncContext<'a>(pub(crate) &'a CarburetorSyncGroup);
+
+impl<'a> AsSyncContext<'a> {
+    pub(crate) fn get_model_name(&self) -> Ident {
+        Ident::new("SyncContext", self.0.name.span())
+    }
+
+    pub(crate) fn has_context(&self) -> bool {
+        !self.0.contexts.is_empty()
+    }
+}
+
+impl<'a> ToTokens for AsSyncContext<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if !self.has_context() {
+            return;
+        }
+        let model_name = self.get_model_name();
+        let fields = self
+            .0
+            .contexts
+            .iter()
+            .map(|(var_name, diesel_type)| {
+                let field_ident = parse_str::<Ident>(var_name).unwrap();
+                let field_type = parse_str::<Type>(&diesel_type.get_model_type_string()).unwrap();
+                quote!(pub #field_ident: #field_type)
+            })
+            .collect::<Vec<_>>();
+
+        tokens.extend(quote! {
+            #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+            pub struct #model_name {
+                #(#fields,)*
+            }
+        });
+    }
+}
+
+pub fn generate_context_models(tokens: &mut TokenStream, sync_group: &CarburetorSyncGroup) {
+    tokens.extend(AsSyncContext(sync_group).to_token_stream());
+}

--- a/carburetor-macro/src/generators/diesel/models.rs
+++ b/carburetor-macro/src/generators/diesel/models.rs
@@ -205,12 +205,10 @@ impl<'a> ToTokens for AsChangesetModel<'a> {
                 #[cfg(feature = "backend")]
                 {
                     use crate::parsers::table::column::ClientOnlyConfig;
-                    match (&x.column_type, &x.client_only_config) {
-                        (CarburetorColumnType::Id, _) => Some(quote!(pub #name: #ty)),
-                        (_, ClientOnlyConfig::Enabled { .. }) => None,
-                        (_, ClientOnlyConfig::Disabled { .. }) => {
-                            Some(quote!(pub #name: Option<#ty>))
-                        }
+                    match (&x.column_type, &x.client_only_config, &x.is_immutable) {
+                        (CarburetorColumnType::Id, _, _) => Some(quote!(pub #name: #ty)),
+                        (_, ClientOnlyConfig::Enabled { .. }, _) | (_, _, true) => None,
+                        (_, _, _) => Some(quote!(pub #name: Option<#ty>)),
                     }
                 }
                 #[cfg(feature = "client")]
@@ -283,4 +281,3 @@ pub(crate) fn generate_diesel_model(tokens: &mut TokenStream, table: &Carburetor
     #[cfg(feature = "backend")]
     tokens.extend(AsInsertModel(&table).to_token_stream());
 }
-

--- a/carburetor-macro/src/generators/download/functions.rs
+++ b/carburetor-macro/src/generators/download/functions.rs
@@ -8,9 +8,7 @@ mod client {
     use quote::{ToTokens, format_ident, quote};
 
     use crate::{
-        generators::{
-            diesel::schema::AsSchemaTable, download::models::AsDownloadRequestModel,
-        },
+        generators::{diesel::schema::AsSchemaTable, download::models::AsDownloadRequestModel},
         parsers::sync_group::CarburetorSyncGroup,
     };
 
@@ -26,7 +24,9 @@ mod client {
                 .iter()
                 .map(|x| {
                     let field_name = format_ident!("{}_offset", x.reference_table.ident);
-                    let table_name_str = AsSchemaTable(&x.reference_table).get_table_name().to_string();
+                    let table_name_str = AsSchemaTable(&x.reference_table)
+                        .get_table_name()
+                        .to_string();
                     quote!(#field_name: offsets.get(#table_name_str).cloned())
                 })
                 .collect::<Vec<_>>();
@@ -52,50 +52,60 @@ mod client {
 
 #[cfg(feature = "backend")]
 mod backend {
-    use std::rc::Rc;
-
     use proc_macro2::TokenStream;
     use quote::{ToTokens, quote};
     use syn::{ExprField, Ident, Path, Type, parse_quote, parse_str};
 
     use crate::{
         generators::{
+            context::models::AsSyncContext,
             diesel::schema::AsSchemaTable,
             download::models::{
                 AsDownloadRequestModel, AsDownloadResponseModel, AsDownloadResponseTableModel,
             },
         },
-        parsers::{sync_group::CarburetorSyncGroup, table::CarburetorTable},
+        parsers::sync_group::CarburetorSyncGroup,
     };
 
-    struct AsResponseFieldValue<'a>(&'a Rc<CarburetorTable>);
+    struct AsResponseFieldValue<'a>(&'a crate::parsers::sync_group::SyncGroupTableConfig);
 
     impl<'a> ToTokens for AsResponseFieldValue<'a> {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            let table = self.0;
+            let table = &self.0.reference_table;
             let field_name = table.ident.clone();
             let function_name = parse_str::<Ident>(&format!("download_{}", &table.ident)).unwrap();
             let function_argument =
                 parse_str::<ExprField>(&format!("request.{}_offset", &table.ident)).unwrap();
 
+            let context_arg = if self.0.restrict_to.is_some() {
+                quote!(context,)
+            } else {
+                quote!()
+            };
+
             tokens.extend(quote! {
-                #field_name: #function_name(#function_argument, clean_download)?
+                #field_name: #function_name(#function_argument, clean_download, #context_arg)?
             });
         }
     }
 
-    struct AsDownloadFunction<'a>(&'a CarburetorSyncGroup, &'a CarburetorTable);
+    struct AsDownloadFunction<'a>(
+        &'a CarburetorSyncGroup,
+        &'a crate::parsers::sync_group::SyncGroupTableConfig,
+    );
 
     impl<'a> ToTokens for AsDownloadFunction<'a> {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            let table = self.1;
+            let table = &self.1.reference_table;
             let function_name = parse_str::<Ident>(&format!("download_{}", &table.ident)).unwrap();
             let model_name = AsDownloadResponseTableModel(&self.0, &table).get_model_name();
             let table_name = AsSchemaTable(table).get_table_name_with_prefix("super");
-            let last_synced_at_column_name = table.sync_metadata_columns.last_synced_at.ident.clone();
+            let last_synced_at_column_name =
+                table.sync_metadata_columns.last_synced_at.ident.clone();
             let is_deleted_column_name = table.sync_metadata_columns.is_deleted.ident.clone();
 
-            let download_sync_response: Path = parse_quote! {carburetor::models::DownloadTableResponse};
+            let download_sync_response: Path =
+                parse_quote! {carburetor::models::DownloadTableResponse};
             let download_sync_response_data: Path =
                 parse_quote! {carburetor::models::DownloadTableResponseData};
 
@@ -105,10 +115,26 @@ mod backend {
                 >
             };
 
+            let (context_param, restrict_filter) = if let Some(ref restrict) = self.1.restrict_to {
+                let context_var = parse_str::<Ident>(&restrict.context_variable).unwrap();
+                let restrict_col = &restrict.column_reference.ident;
+                (
+                    quote!(context: &SyncContext,),
+                    quote! {
+                        query = query.filter(
+                            #table_name::dsl::#restrict_col.eq(&context.#context_var)
+                        );
+                    },
+                )
+            } else {
+                (quote!(), quote!())
+            };
+
             tokens.extend(quote! {
                 fn #function_name(
                     offset: Option<carburetor::chrono::DateTimeUtc>,
-                    clean_download: bool
+                    clean_download: bool,
+                    #context_param
                 ) -> #return_type
                 {
                     use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, SelectableHelper};
@@ -127,6 +153,8 @@ mod backend {
                     if clean_download {
                         query = query.filter(#table_name::dsl::#is_deleted_column_name.eq(false));
                     }
+
+                    #restrict_filter
 
                     Ok(#download_sync_response {
                         cutoff_at: process_time,
@@ -157,19 +185,28 @@ mod backend {
                 .0
                 .table_configs
                 .iter()
-                .map(|x| AsDownloadFunction(&self.0, &x.reference_table))
+                .map(|x| AsDownloadFunction(&self.0, x))
                 .collect::<Vec<_>>();
 
             let table_response_field_values = self
                 .0
                 .table_configs
                 .iter()
-                .map(|x| AsResponseFieldValue(&x.reference_table))
+                .map(|x| AsResponseFieldValue(x))
                 .collect::<Vec<_>>();
+
+            let has_context = AsSyncContext(self.0).has_context();
+            let context_param = if has_context {
+                let sync_context_name = AsSyncContext(self.0).get_model_name();
+                quote!(context: &#sync_context_name,)
+            } else {
+                quote!()
+            };
 
             token.extend(quote! {
                 pub fn #function_name(
                     request: Option<#request_model_name>,
+                    #context_param
                 ) -> carburetor::error::Result<#response_model_name> {
                     let clean_download = request.is_none();
                     let request = request.unwrap_or_default();

--- a/carburetor-macro/src/generators/mod.rs
+++ b/carburetor-macro/src/generators/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "client")]
 pub(crate) mod client;
+pub(crate) mod context;
 pub(crate) mod diesel;
 pub(crate) mod download;
 pub(crate) mod upload;
@@ -38,6 +39,13 @@ pub(crate) fn generate_carburetor_sync_config(
             &mut mod_tokens,
             &x,
         );
+
+        #[cfg(feature = "backend")]
+        {
+            use crate::generators::context::models::generate_context_models;
+
+            generate_context_models(&mut mod_tokens, x);
+        }
 
         #[cfg(feature = "client")]
         {

--- a/carburetor-macro/src/generators/upload/functions.rs
+++ b/carburetor-macro/src/generators/upload/functions.rs
@@ -283,6 +283,13 @@ mod client {
                                     carburetor::models::UploadTableResponseErrorType::RecordNotFound => {
                                         // TODO: handle by creating the record as insert record instead
                                     }
+                                    carburetor::models::UploadTableResponseErrorType::InsufficientPermission => {
+                                        // TODO: handle by creating the record as insert record instead
+                                        //       we probably can safely assume that this is
+                                        //       happening because of update error, insert errors
+                                        //       are to be handled by the developer for mismatch
+                                        //       context between the backend and client
+                                    }
                                     carburetor::models::UploadTableResponseErrorType::Unknown => {
                                         // Nothing to do because we don't know what's happening
                                     }
@@ -342,10 +349,11 @@ mod client {
 mod backend {
     use proc_macro2::TokenStream;
     use quote::{ToTokens, format_ident, quote};
-    use syn::Ident;
+    use syn::{Ident, parse_str};
 
     use crate::{
         generators::{
+            context::models::AsSyncContext,
             diesel::{
                 models::{AsChangesetModel, AsFullModel, backend::AsInsertModel},
                 schema::AsSchemaTable,
@@ -399,10 +407,47 @@ mod backend {
                 })
                 .collect::<Vec<_>>();
 
+            let (context_param, insert_context_validation, update_context_validation) =
+                if let Some(ref restrict) = self.0.restrict_to {
+                    let context_var = parse_str::<syn::Ident>(&restrict.context_variable).unwrap();
+                    let restrict_col = &restrict.column_reference.ident;
+                    (
+                        quote!(context: &SyncContext,),
+                        quote! {
+                            if &data.#restrict_col != &context.#context_var {
+                                return Err(carburetor::models::UploadTableResponseError {
+                                    id: data.#id_column.clone(),
+                                    code: carburetor::models::UploadTableResponseErrorType::InsufficientPermission,
+                                });
+                            }
+                        },
+                        quote! {
+                            use diesel::{QueryDsl, RunQueryDsl, SelectableHelper};
+                            let existing = super::#table_name::table
+                                .select(#full_model_name::as_select())
+                                .find(&data.#id_column)
+                                .first(connection)
+                                .map_err(|_| carburetor::models::UploadTableResponseError {
+                                    id: data.#id_column.clone(),
+                                    code: carburetor::models::UploadTableResponseErrorType::RecordNotFound,
+                                })?;
+                            if &existing.#restrict_col != &context.#context_var {
+                                return Err(carburetor::models::UploadTableResponseError {
+                                    id: data.#id_column.clone(),
+                                    code: carburetor::models::UploadTableResponseErrorType::InsufficientPermission,
+                                });
+                            }
+                        },
+                    )
+                } else {
+                    (quote!(), quote!(), quote!())
+                };
+
             tokens.extend(quote! {
                 fn #function_name(
                     requests: Vec<#upload_request_table_name>,
                     connection: &mut diesel::PgConnection,
+                    #context_param
                 ) -> Vec<
                     Result<
                         carburetor::models::UploadTableResponseData,
@@ -415,6 +460,7 @@ mod backend {
                         .map(|x| {
                             match x {
                                 #upload_request_table_name::Insert(data) => {
+                                    #insert_context_validation
                                     let insert_data = #insert_model_name::from(data);
                                     let id_to_insert = insert_data.#id_column.clone();
                                     diesel::insert_into(super::#table_name::table)
@@ -443,6 +489,7 @@ mod backend {
                                         })
                                 }
                                 #upload_request_table_name::Update(data) => {
+                                    #update_context_validation
                                     let update_data = #changeset_model_name::from(data);
                                     let id_to_update = update_data.#id_column.clone();
                                     diesel::update(super::#table_name::table.find(&update_data.#id_column))
@@ -495,13 +542,27 @@ mod backend {
                 .map(|x| {
                     let field = &x.reference_table.ident;
                     let function_name = AsProcessTableUploadFunction(x).get_function_name();
-                    quote!(#field: #function_name(upload_request.#field, &mut connection))
+                    let context_arg = if x.restrict_to.is_some() {
+                        quote!(context,)
+                    } else {
+                        quote!()
+                    };
+                    quote!(#field: #function_name(upload_request.#field, &mut connection, #context_arg))
                 })
                 .collect::<Vec<_>>();
+
+            let has_context = AsSyncContext(self.0).has_context();
+            let context_param = if has_context {
+                let sync_context_name = AsSyncContext(self.0).get_model_name();
+                quote!(context: &#sync_context_name,)
+            } else {
+                quote!()
+            };
 
             tokens.extend(quote! {
                 pub fn process_upload_request(
                     upload_request: #upload_request_model_name,
+                    #context_param
                 ) -> carburetor::error::Result<#upload_response_model_name> {
 
                     #(#table_process_functions)*

--- a/carburetor-macro/src/generators/upload/models.rs
+++ b/carburetor-macro/src/generators/upload/models.rs
@@ -70,6 +70,7 @@ pub mod client {
                         Some(quote!(#field_name: self.#field_name))
                     } else if x.client_only_config == ClientOnlyConfig::Disabled
                         && x.mod_on_backend_only_config == BackendOnlyConfig::Disabled
+                        && !x.is_immutable
                     {
                         let field_name = &x.ident;
                         Some(quote! {
@@ -139,7 +140,7 @@ pub mod backend {
         generators::diesel::models::{AsChangesetModel, backend::AsInsertModel},
         parsers::{
             sync_group::SyncGroupTableConfig,
-            table::column::{BackendOnlyConfig, ClientOnlyConfig},
+            table::column::{BackendOnlyConfig, CarburetorColumnType, ClientOnlyConfig},
         },
     };
 
@@ -194,7 +195,9 @@ pub mod backend {
                 .columns
                 .iter()
                 .filter_map(|x| {
-                    if x.client_only_config != ClientOnlyConfig::Disabled {
+                    if x.client_only_config != ClientOnlyConfig::Disabled
+                        || (x.column_type != CarburetorColumnType::Id && x.is_immutable)
+                    {
                         return None;
                     }
 
@@ -234,6 +237,7 @@ impl<'a> ToTokens for AsUploadUpdateTable<'a> {
                 })
             } else if x.client_only_config == ClientOnlyConfig::Disabled
                 && x.mod_on_backend_only_config == BackendOnlyConfig::Disabled
+                && !x.is_immutable
             {
                 let field_name = &x.ident;
                 let field_type = AsModelType(&x.diesel_type);

--- a/carburetor-macro/src/parsers/mod.rs
+++ b/carburetor-macro/src/parsers/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod table;
 use std::rc::Rc;
 
 use syn::{
-    Error, Ident, Result,
+    Error, Result,
     parse::{Parse, ParseStream, Parser},
     punctuated::Punctuated,
     token,
@@ -13,7 +13,9 @@ use syn::{
 use syntax::block::DeclarationBlock;
 
 use crate::parsers::{
-    sync_group::CarburetorSyncGroup, syntax::iterative::IterativeParsing, table::CarburetorTable,
+    sync_group::CarburetorSyncGroup,
+    syntax::{block::DeclarationSettingBlock, iterative::IterativeParsing},
+    table::CarburetorTable,
 };
 
 pub(crate) struct CarburetorSyncConfig {
@@ -57,7 +59,7 @@ impl Parse for CarburetorSyncConfig {
                         .map(|x| {
                             Ok(CarburetorSyncGroup::from_lookup_table_names(
                                 x.ident,
-                                &Punctuated::<Ident, token::Comma>::parse_terminated
+                                &Punctuated::<DeclarationSettingBlock, token::Comma>::parse_terminated
                                     .parse2(x.content)?
                                     .into_iter()
                                     .collect::<Vec<_>>(),

--- a/carburetor-macro/src/parsers/sync_group.rs
+++ b/carburetor-macro/src/parsers/sync_group.rs
@@ -1,42 +1,152 @@
-use std::rc::Rc;
+use std::{collections::HashMap, rc::Rc};
 
+use proc_macro2::Span;
+use quote::ToTokens;
 use syn::{Error, Ident, Result};
 
-use crate::parsers::table::CarburetorTable;
+use crate::parsers::{
+    syntax::block::{DeclarationArgument, DeclarationSettingBlock},
+    table::{CarburetorTable, column::CarburetorColumn, postgres_type::DieselPostgresType},
+};
 
+#[derive(Debug, Clone)]
 pub(crate) struct CarburetorSyncGroup {
     pub(crate) name: Ident,
     pub(crate) table_configs: Vec<SyncGroupTableConfig>,
+    pub(crate) contexts: HashMap<String, DieselPostgresType>,
 }
 
 impl CarburetorSyncGroup {
     pub(crate) fn from_lookup_table_names(
         name: Ident,
-        table_names: &[Ident],
+        table_settings: &[DeclarationSettingBlock],
         tables_lookup: &[Rc<CarburetorTable>],
     ) -> Result<Self> {
+        let mut contexts = HashMap::new();
         Ok(Self {
             name,
-            table_configs: table_names
-                .into_iter()
+            table_configs: table_settings
+                .iter()
                 .map(|x| {
                     let message = "Table in sync group does not exist in table declaration";
                     Ok(tables_lookup
                         .into_iter()
-                        .find(|table| table.ident.to_string() == x.to_string())
-                        .ok_or(Error::new_spanned(x, message))
-                        .map(|x| SyncGroupTableConfig {
-                            reference_table: x.clone(),
+                        .find(|table| table.ident.to_string() == x.ident.to_string())
+                        .ok_or(Error::new_spanned(x.ident.clone(), message))
+                        .and_then(|lookup_table| {
+                            let config = SyncGroupTableConfig::new_with_arguments(
+                                lookup_table.clone(),
+                                &x.arguments,
+                            );
+                            if let Ok(ref c) = config
+                                && let Some(ref restrict_to) = c.restrict_to
+                            {
+                                let value = contexts.get(&restrict_to.context_variable);
+                                if let Some(v) = value {
+                                    if v != &restrict_to.column_reference.diesel_type {}
+                                } else {
+                                    contexts.insert(
+                                        restrict_to.context_variable.clone(),
+                                        restrict_to.column_reference.diesel_type.clone(),
+                                    );
+                                }
+                            }
+                            config
                         })?)
                 })
                 .collect::<Result<Vec<_>>>()?,
+            contexts,
         })
     }
 }
 
 #[derive(Debug, Clone)]
+pub struct SyncGroupTableRestrictToConfig {
+    pub context_variable: String,
+    pub column_reference: Rc<CarburetorColumn>,
+}
+
+#[derive(Debug, Clone)]
 pub struct SyncGroupTableConfig {
     pub reference_table: Rc<CarburetorTable>,
+    pub restrict_to: Option<SyncGroupTableRestrictToConfig>,
+}
+
+impl SyncGroupTableConfig {
+    fn new_with_arguments(
+        reference_table: Rc<CarburetorTable>,
+        arguments: &[DeclarationArgument],
+    ) -> Result<Self> {
+        let mut maybe_restrict_to = None;
+        let mut maybe_restrict_to_column = None;
+        for arg in arguments {
+            match arg.name.to_string().as_str() {
+                "restrict_to" => {
+                    if maybe_restrict_to.is_some() {
+                        return Err(Error::new_spanned(&arg.name, "Duplicate arguments found"));
+                    }
+                    if !arg.value.dollar_prefixed {
+                        return Err(Error::new_spanned(
+                            &arg.name,
+                            "Variable assigned to `restrict_to` should be prefixed with dollar to mark that it is accessing to context variable",
+                        ));
+                    }
+                    maybe_restrict_to = Some(arg.value.name.to_token_stream().to_string());
+                }
+                "restrict_to_column" => {
+                    if maybe_restrict_to_column.is_some() {
+                        return Err(Error::new_spanned(&arg.name, "Duplicate arguments found"));
+                    }
+                    if arg.value.dollar_prefixed {
+                        return Err(Error::new_spanned(
+                            &arg.name,
+                            "Context variable cannot be used here",
+                        ));
+                    }
+                    let restrict_to_column = reference_table
+                        .columns
+                        .iter()
+                        .find(|x| {
+                            x.ident.to_string() == arg.value.name.to_token_stream().to_string()
+                        })
+                        .cloned()
+                        .ok_or(Error::new_spanned(
+                            &arg.name,
+                            &format!(
+                                "No such column in `{}` table",
+                                reference_table.ident.to_string()
+                            ),
+                        ))?;
+                    if !restrict_to_column.is_immutable {
+                        return Err(Error::new_spanned(
+                            &restrict_to_column.ident,
+                            "Referenced column for `restrict_to_column` must be immutable",
+                        ));
+                    }
+                    maybe_restrict_to_column = Some(restrict_to_column);
+                }
+                _ => {
+                    return Err(Error::new_spanned(&arg.name, "Unknown argument found"));
+                }
+            }
+        }
+        if maybe_restrict_to_column.is_none() != maybe_restrict_to.is_none() {
+            return Err(Error::new(
+                Span::call_site(),
+                "`restrict_to` and `restrict_to_column` must be set in pair",
+            ));
+        }
+        Ok(Self {
+            reference_table,
+            restrict_to: match (maybe_restrict_to_column, maybe_restrict_to) {
+                (Some(col), Some(var)) => Some(SyncGroupTableRestrictToConfig {
+                    context_variable: var,
+                    column_reference: col,
+                }),
+                _ => None,
+            },
+        })
+    }
 }
 
 #[cfg(test)]
@@ -79,12 +189,15 @@ mod tests {
     #[test]
     fn test_from_lookup_table_names_single_table() {
         let tables_lookup = vec![create_test_table("user")];
-        let table_names = vec![format_ident!("user")];
+        let table_settings = vec![DeclarationSettingBlock {
+            ident: format_ident!("user"),
+            arguments: vec![],
+        }];
         let name = format_ident!("test_group");
 
         let result = CarburetorSyncGroup::from_lookup_table_names(
             name.clone(),
-            &table_names,
+            &table_settings,
             &tables_lookup,
         )
         .unwrap();
@@ -104,12 +217,21 @@ mod tests {
             create_test_table("post"),
             create_test_table("comment"),
         ];
-        let table_names = vec![format_ident!("user"), format_ident!("comment")];
+        let table_settings = vec![
+            DeclarationSettingBlock {
+                ident: format_ident!("user"),
+                arguments: vec![],
+            },
+            DeclarationSettingBlock {
+                ident: format_ident!("comment"),
+                arguments: vec![],
+            },
+        ];
         let name = format_ident!("content_group");
 
         let result = CarburetorSyncGroup::from_lookup_table_names(
             name.clone(),
-            &table_names,
+            &table_settings,
             &tables_lookup,
         )
         .unwrap();
@@ -129,11 +251,14 @@ mod tests {
     #[test]
     fn test_from_lookup_table_names_table_not_found() {
         let tables_lookup = vec![create_test_table("user")];
-        let table_names = vec![format_ident!("non_existent")];
+        let table_settings = vec![DeclarationSettingBlock {
+            ident: format_ident!("non_existent"),
+            arguments: vec![],
+        }];
         let name = format_ident!("test_group");
 
         let result =
-            CarburetorSyncGroup::from_lookup_table_names(name, &table_names, &tables_lookup);
+            CarburetorSyncGroup::from_lookup_table_names(name, &table_settings, &tables_lookup);
 
         assert!(result.is_err());
     }

--- a/carburetor-macro/src/parsers/syntax/block.rs
+++ b/carburetor-macro/src/parsers/syntax/block.rs
@@ -1,11 +1,28 @@
 use proc_macro2::TokenStream;
 use syn::{
-    Error, Expr, Ident, MetaNameValue, Result, braced, parenthesized,
+    Expr, ExprPath, Ident, Result, braced, parenthesized,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     token,
 };
 
+/// Represents a parsed block declaration in macro input.
+///
+/// # Examples
+///
+/// Basic block with no arguments:
+/// ```text
+/// foo {
+///     // block content
+/// }
+/// ```
+///
+/// Block with arguments:
+/// ```text
+/// foo(a = "app", b = bar) {
+///     // block content
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub(crate) struct DeclarationBlock {
     pub(crate) ident: Ident,
@@ -13,51 +30,105 @@ pub(crate) struct DeclarationBlock {
     pub(crate) content: TokenStream,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct DeclarationArgument {
-    pub(crate) name: Ident,
-    pub(crate) value: Expr,
+impl Parse for DeclarationBlock {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let setting_block: DeclarationSettingBlock = input.parse()?;
+
+        let content;
+        braced!(content in input);
+        let content: TokenStream = content.parse()?;
+
+        Ok(Self {
+            ident: setting_block.ident,
+            arguments: setting_block.arguments,
+            content,
+        })
+    }
 }
 
-impl Parse for DeclarationBlock {
+/// Represents a parsed block declaration in macro input that consists only of an identifier and
+/// optional arguments, but does not include a braced content body.
+///
+/// This is similar to [`DeclarationBlock`], but omits the braces and inner content. Used for
+/// settings or configuration-like declarations where only the block name and arguments are
+/// required.
+///
+/// # Examples
+///
+/// Basic setting block with no arguments: `foo`
+///
+/// Setting block with arguments: `foo(a = "app", b = bar)`
+#[derive(Debug, Clone)]
+pub(crate) struct DeclarationSettingBlock {
+    pub(crate) ident: Ident,
+    pub(crate) arguments: Vec<DeclarationArgument>,
+}
+impl Parse for DeclarationSettingBlock {
     fn parse(input: ParseStream) -> Result<Self> {
         let ident: Ident = input.parse()?;
         let mut arguments = vec![];
         if input.peek(token::Paren) {
             let args;
             parenthesized!(args in input);
-            // TODO support for multiple arguments
-            let args = Punctuated::<MetaNameValue, token::Eq>::parse_terminated(&args)?;
-            arguments = args
-                .into_iter()
-                .map(|x| -> Result<_> {
-                    Ok(DeclarationArgument {
-                        name: x
-                            .path
-                            .get_ident()
-                            .ok_or(Error::new_spanned(&x.path, "Argument key is missing"))?
-                            .clone(),
-                        value: x.value,
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
+            let args = Punctuated::<DeclarationArgument, token::Comma>::parse_terminated(&args)?;
+            arguments = args.into_iter().collect::<Vec<_>>();
         }
-        let content;
-        braced!(content in input);
-        let content: TokenStream = content.parse()?;
+
+        Ok(Self { ident, arguments })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DeclarationArgument {
+    pub(crate) name: Ident,
+    pub(crate) value: DeclarationArgumentValue,
+}
+
+impl Parse for DeclarationArgument {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let name = input.parse()?;
+        let _: token::Eq = input.parse()?;
 
         Ok(Self {
-            ident,
-            arguments,
-            content,
+            name,
+            value: input.parse()?,
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DeclarationArgumentValue {
+    pub(crate) name: Expr,
+    pub(crate) dollar_prefixed: bool,
+}
+
+impl Parse for DeclarationArgumentValue {
+    fn parse(input: ParseStream) -> Result<Self> {
+        if input.peek(token::Dollar) {
+            let _: token::Dollar = input.parse()?;
+            let ident: Ident = input.parse()?;
+
+            Ok(Self {
+                name: Expr::Path(ExprPath {
+                    attrs: vec![],
+                    qself: None,
+                    path: ident.into(),
+                }),
+                dollar_prefixed: true,
+            })
+        } else {
+            Ok(Self {
+                name: input.parse()?,
+                dollar_prefixed: false,
+            })
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
+    use quote::{ToTokens, quote};
     use syn::parse2;
 
     #[test]
@@ -100,5 +171,23 @@ mod tests {
 
         assert_eq!(result.ident.to_string(), "BlockWithEmptyParens");
         assert!(result.arguments.is_empty());
+    }
+
+    #[test]
+    fn test_declaration_argument_value() {
+        let result: DeclarationArgumentValue = parse2(quote!("value")).unwrap();
+        assert_eq!(
+            result.name.to_token_stream().to_string(),
+            "\"value\"".to_string()
+        );
+        assert_eq!(result.dollar_prefixed, false);
+        let result: DeclarationArgumentValue = parse2(quote!($value)).unwrap();
+        assert_eq!(
+            result.name.to_token_stream().to_string(),
+            "value".to_string()
+        );
+        assert_eq!(result.dollar_prefixed, true);
+        let result: Result<DeclarationArgumentValue> = parse2(quote!($"value"));
+        assert!(result.is_err());
     }
 }

--- a/carburetor-macro/src/parsers/table/column.rs
+++ b/carburetor-macro/src/parsers/table/column.rs
@@ -25,6 +25,7 @@ pub(crate) struct CarburetorColumn {
     pub(crate) client_only_config: ClientOnlyConfig,
     pub(crate) mod_on_backend_only_config: BackendOnlyConfig,
     pub(crate) column_type: CarburetorColumnType,
+    pub(crate) is_immutable: bool,
 }
 
 impl TryFrom<DieselTableStyleContent> for CarburetorColumn {
@@ -35,6 +36,7 @@ impl TryFrom<DieselTableStyleContent> for CarburetorColumn {
         let mut column_type = CarburetorColumnType::default();
         let mut client_only = ClientOnlyConfig::default();
         let mut backend_mod = BackendOnlyConfig::default();
+        let mut is_immutable = false;
 
         for attr in value.attrs.iter() {
             let ident: Ident = parse_quote! {#attr};
@@ -111,8 +113,17 @@ impl TryFrom<DieselTableStyleContent> for CarburetorColumn {
                     };
                     column_type = CarburetorColumnType::DirtyFlag;
                 }
+                "immutable" => {
+                    is_immutable = true;
+                }
                 _ => {}
             }
+        }
+        if is_immutable && column_type != CarburetorColumnType::Data {
+            return Err(Error::new_spanned(
+                value.name,
+                "#[immutable] can only be applied to non-special data columns",
+            ));
         }
         Ok(CarburetorColumn {
             ident: value.name,
@@ -120,6 +131,7 @@ impl TryFrom<DieselTableStyleContent> for CarburetorColumn {
             client_only_config: client_only,
             mod_on_backend_only_config: backend_mod,
             column_type,
+            is_immutable,
         })
     }
 }
@@ -175,6 +187,7 @@ impl Default for IdColumn {
             column_type: CarburetorColumnType::Id,
             client_only_config: ClientOnlyConfig::Disabled,
             mod_on_backend_only_config: BackendOnlyConfig::Disabled,
+            is_immutable: true,
         }))
     }
 }
@@ -197,6 +210,7 @@ impl Default for LastSyncedAtColumn {
             column_type: CarburetorColumnType::LastSyncedAt,
             client_only_config: ClientOnlyConfig::Disabled,
             mod_on_backend_only_config: BackendOnlyConfig::BySqlUtcNow,
+            is_immutable: false,
         }))
     }
 }
@@ -219,6 +233,7 @@ impl Default for IsDeletedColumn {
             column_type: CarburetorColumnType::IsDeleted,
             client_only_config: ClientOnlyConfig::Disabled,
             mod_on_backend_only_config: BackendOnlyConfig::Disabled,
+            is_immutable: false,
         }))
     }
 }
@@ -246,6 +261,7 @@ impl Default for DirtyFlagColumn {
                 default_value: quote!(None),
             },
             mod_on_backend_only_config: BackendOnlyConfig::Disabled,
+            is_immutable: false,
         }))
     }
 }
@@ -270,6 +286,7 @@ impl Default for ClientColumnSyncMetadata {
                 default_value: quote!(carburetor::serde_json::from_str("{}").unwrap()),
             },
             mod_on_backend_only_config: BackendOnlyConfig::Disabled,
+            is_immutable: false,
         }))
     }
 }

--- a/carburetor-macro/src/parsers/table/mod.rs
+++ b/carburetor-macro/src/parsers/table/mod.rs
@@ -6,7 +6,6 @@ use syn::{
     Error, Ident, LitStr, Result, Token,
     parse::{Parse, ParseStream, Parser},
     punctuated::Punctuated,
-    spanned::Spanned,
 };
 
 use crate::{
@@ -50,9 +49,15 @@ impl Parse for CarburetorTable {
                     if plural_ident.is_some() {
                         return Err(Error::new_spanned(&arg.name, "Duplicate arguments found"));
                     }
+                    if arg.value.dollar_prefixed {
+                        return Err(Error::new_spanned(
+                            &arg.name,
+                            "Context variable cannot be used here",
+                        ));
+                    }
                     plural_ident = Some(parse_str_as(
-                        &parse_as::<LitStr>(&arg.value)?.value(),
-                        arg.value.span(),
+                        &parse_as::<LitStr>(&arg.value.name)?.value(),
+                        arg.name.span(),
                     )?);
                 }
                 _ => {

--- a/carburetor/src/models.rs
+++ b/carburetor/src/models.rs
@@ -32,4 +32,5 @@ pub enum UploadTableResponseErrorType {
     Unknown,
     RecordNotFound,
     RecordAlreadyExists,
+    InsufficientPermission,
 }

--- a/docs/features/filter-row-by-condition.md
+++ b/docs/features/filter-row-by-condition.md
@@ -1,0 +1,197 @@
+# Filter Row by Condition
+
+## Overview
+
+This feature introduces two mechanisms that together enable fine-grained,
+context-aware access control over what data is synced between the backend and
+clients.
+
+The first mechanism is the `#[immutable]` column attribute, which marks
+user-defined columns as read-only after their initial value is set. This
+prevents any incoming update from overwriting those columns during sync.
+
+The second mechanism is the `restrict_to` and `restrict_to_column` attributes
+on sync group table entries. When applied, they narrow the scope of a sync group
+so that only rows matching a given context value are visible to download and
+writable during upload. The context is provided at runtime through a generated
+`SyncContext` type, making the feature flexible enough to serve any row-level
+filtering need — the most prominent use case being per-user data isolation in
+authenticated applications.
+
+## Core Implementation Library/Framework/Tool
+
+This feature works with the same set of tools utilized in [basic
+feature](./basic-feature.md).
+
+## Feature Components
+
+### Immutable Column Attribute
+
+The `#[immutable]` attribute can be applied to any regular data column in a
+table definition. It signals that once a row is created, that column's value
+must never be changed by an incoming sync update.
+
+```rust
+tables {
+    note(plural = "notes") {
+        #[immutable]
+        owner_id -> Text,
+        content -> Text,
+    }
+}
+```
+
+**Constraints**:
+- Can only be applied to non-special columns. The special columns (`#[id]`,
+  `#[last_synced_at]`, `#[is_deleted]`, `#[dirty_flag]`,
+  `#[client_column_sync_metadata]`) already have their mutability determined
+  implicitly: `id` is always immutable, and the rest follow their own
+  system-managed rules.
+- Applying `#[immutable]` to a special column results in a compile-time error.
+
+**Effect on sync**:
+- On the backend, an `Update` request that includes a value for an immutable
+  column will have that column silently ignored; the persisted value is never
+  overwritten.
+- The `AsChangeset` model generated for the table omits immutable columns, so
+  they cannot participate in `UPDATE` statements.
+
+### Sync Group Row Filtering
+
+Two new attributes on sync group table entries control row-level access:
+
+- `restrict_to`: The name of the field on the generated `SyncContext` struct
+  that holds the filtering value.
+- `restrict_to_column`: The table column whose value must equal the context
+  field value for a row to be included.
+
+Both attributes must be specified together; providing one without the other is a
+compile-time error.
+
+```rust
+sync_groups {
+    per_user_notes {
+        note(
+            restrict_to = $user_id,
+            restrict_to_column = owner_id,
+        )
+    }
+}
+```
+
+#### Generated `SyncContext`
+
+When any table in a sync group declares `restrict_to`, the macro generates a
+`SyncContext` struct for that group. Each unique `restrict_to` variable becomes
+a field on the struct. The type of the field matches the Rust type of the
+corresponding `restrict_to_column`.
+
+For the example above, the generated struct would resemble:
+
+```rust
+pub struct SyncContext {
+    pub user_id: String,
+}
+```
+
+#### Effect on `process_download_request`
+
+The generated `process_download_request` function gains an additional `context:
+SyncContext` parameter. Internally, for each restricted table, an equality
+filter is added to the query so that only rows where `<restrict_to_column> =
+context.<restrict_to>` are returned.
+
+```rust
+// Generated signature (backend, with restriction)
+pub fn process_download_request(
+    request: Option<DownloadRequest>,
+    context: SyncContext,
+) -> carburetor::error::Result<DownloadResponse>
+```
+
+#### Effect on `process_upload_request`
+
+The generated `process_upload_request` function also gains the `context:
+SyncContext` parameter. Before applying any insert or update, the backend
+validates that the value of the restricted column in the incoming record matches
+the corresponding context field. Records that fail this check are rejected with
+an appropriate error response for that row.
+
+```rust
+// Generated signature (backend, with restriction)
+pub fn process_upload_request(
+    request: UploadRequest,
+    context: SyncContext,
+) -> carburetor::error::Result<UploadResponse>
+```
+
+#### Groups without restrictions
+
+When a sync group has no `restrict_to` / `restrict_to_column` attributes on any
+of its tables, no `SyncContext` struct is generated for that group and the
+signatures of `process_download_request` and `process_upload_request` remain
+unchanged from the basic feature.
+
+### Usage Example
+
+A typical authenticated scenario: each user may only sync their own notes.
+
+```rust
+carburetor_sync_config! {
+    tables {
+        note(plural = "notes") {
+            #[immutable]
+            owner_id -> Text,
+            content -> Text,
+        }
+    }
+    sync_groups {
+        per_user_notes {
+            note(
+                restrict_to = $user_id,
+                restrict_to_column = owner_id,
+            )
+        }
+    }
+}
+```
+
+On the backend, the caller constructs a `SyncContext` from the authenticated
+session and passes it to the generated functions:
+
+```rust
+let context = per_user_notes::SyncContext {
+    user_id: authenticated_user_id,
+};
+
+let response = per_user_notes::process_download_request(request, context)?;
+```
+
+Because `SyncContext` is a plain struct with no internal validation, any value
+can be supplied. The application is responsible for populating it from a trusted
+source such as a verified session token or middleware-resolved identity.
+
+## Challenges and Considerations
+
+### SyncContext Is Not Self-Enforcing
+
+`SyncContext` carries no authentication logic itself. If an incorrect or
+forged value is passed (for example, due to a missing authentication middleware
+layer), the filter will silently allow or deny rows based on that wrong value.
+Applications must ensure that the context is populated from a trusted,
+server-side source before calling the generated functions.
+
+### Immutability Is Enforced Only During Sync
+
+The `#[immutable]` guarantee applies to the sync path. Direct database writes
+that bypass the generated functions are not covered. Applications that allow
+raw database access must enforce their own immutability constraints at the
+database level (e.g., via triggers or application-layer guards) if that
+protection is required outside of sync.
+
+### Single Column Restriction per Table
+
+Each `restrict_to` / `restrict_to_column` pair ties one context field to one
+column for each table. The current design decision disables multiple condition
+on a single table because it makes things complex and there aren't any strong
+use case to support it right now.

--- a/tests/e2e-test/src/lib.rs
+++ b/tests/e2e-test/src/lib.rs
@@ -151,6 +151,21 @@ impl TestClientDatabase {
         .expect("Failed to create users table");
 
         diesel::sql_query(
+            "CREATE TABLE messages(
+                id TEXT PRIMARY KEY,
+                recipient_id TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                body TEXT NOT NULL,
+                last_synced_at TIMESTAMPTZ,
+                is_deleted BOOLEAN NOT NULL,
+                dirty_flag TEXT,
+                column_sync_metadata JSON NOT NULL
+            )",
+        )
+        .execute(&mut conn)
+        .expect("Failed to create messages table");
+
+        diesel::sql_query(
             "CREATE TABLE carburetor_offsets(
                 table_name TEXT PRIMARY KEY,
                 cutoff_at TIMESTAMPTZ NOT NULL

--- a/tests/e2e-test/src/lib.rs
+++ b/tests/e2e-test/src/lib.rs
@@ -140,6 +140,7 @@ impl TestClientDatabase {
                 username TEXT NOT NULL,
                 first_name TEXT,
                 joined_on DATE NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL,
                 last_synced_at TIMESTAMPTZ,
                 is_deleted BOOLEAN NOT NULL,
                 dirty_flag TEXT,

--- a/tests/e2e-test/tests/edge_cases/dirty_while_upload.rs
+++ b/tests/e2e-test/tests/edge_cases/dirty_while_upload.rs
@@ -1,6 +1,6 @@
 use diesel::{RunQueryDsl, SelectableHelper, query_dsl::methods::SelectDsl};
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::schema::all_clients;
+use sample_test_core::schema::user_only;
 use tarpc::context::current as ctx;
 
 #[tokio::test]
@@ -10,7 +10,7 @@ async fn test_upload_insert_and_update_between_retrieve_and_store() {
     let backend = backend_server.client().await;
 
     // Insert a user — dirty_flag="insert"
-    let inserted = all_clients::insert_user(all_clients::InsertUser {
+    let inserted = user_only::insert_user(user_only::InsertUser {
         username: "user_v1".to_string(),
         first_name: Some("V1".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
@@ -19,11 +19,11 @@ async fn test_upload_insert_and_update_between_retrieve_and_store() {
     .unwrap();
 
     // Retrieve upload request — cutoff captured here
-    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(upload_request.user.len(), 1);
 
     // Update the user AFTER cutoff — simulates mutation between retrieve and store
-    all_clients::update_user(all_clients::UpdateUser {
+    user_only::update_user(user_only::UpdateUser {
         id: inserted.id.clone(),
         username: Some("user_v2".to_string()),
         first_name: None,
@@ -33,7 +33,7 @@ async fn test_upload_insert_and_update_between_retrieve_and_store() {
 
     // Send original upload request to backend (backend processes the insert)
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert_eq!(upload_response.user.len(), 1);
@@ -41,10 +41,10 @@ async fn test_upload_insert_and_update_between_retrieve_and_store() {
 
     // Store response — insert_time clears (was before cutoff), but username dirty_at is after
     // cutoff so dirty_flag should become "update" rather than None
-    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+    user_only::store_upload_response(cutoff, upload_response).unwrap();
 
-    let users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
     assert_eq!(users.len(), 1);
@@ -77,12 +77,11 @@ async fn test_upload_update_and_update_same_column_between_retrieve_and_store() 
         .unwrap();
 
     let before_seed = backend
-        .test_helper_get_user(ctx(), "user-edge-1".to_string())
+        .test_helper_get_user_last_synced_at(ctx(), "user-edge-1".to_string())
         .await
-        .unwrap()
-        .last_synced_at;
+        .unwrap();
 
-    let synced_user = all_clients::FullUser {
+    let synced_user = user_only::FullUser {
         id: "user-edge-1".to_string(),
         username: "original".to_string(),
         first_name: Some("Original".to_string()),
@@ -93,13 +92,13 @@ async fn test_upload_update_and_update_same_column_between_retrieve_and_store() 
         dirty_flag: None,
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&synced_user)
         .execute(&mut conn)
         .unwrap();
 
     // First update — dirty_at for username = T0
-    all_clients::update_user(all_clients::UpdateUser {
+    user_only::update_user(user_only::UpdateUser {
         id: "user-edge-1".to_string(),
         username: Some("updated_v1".to_string()),
         first_name: None,
@@ -108,11 +107,11 @@ async fn test_upload_update_and_update_same_column_between_retrieve_and_store() 
     .unwrap();
 
     // Retrieve upload request — cutoff = T1 (> T0)
-    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(upload_request.user.len(), 1);
 
     // Second update to same column AFTER cutoff — dirty_at for username = T2 (> T1)
-    all_clients::update_user(all_clients::UpdateUser {
+    user_only::update_user(user_only::UpdateUser {
         id: "user-edge-1".to_string(),
         username: Some("updated_v2".to_string()),
         first_name: None,
@@ -122,17 +121,17 @@ async fn test_upload_update_and_update_same_column_between_retrieve_and_store() 
 
     // Send first update to backend
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert_eq!(upload_response.user.len(), 1);
     assert!(upload_response.user[0].is_ok());
 
     // Store response — username dirty_at T2 > cutoff T1, so it must remain dirty
-    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+    user_only::store_upload_response(cutoff, upload_response).unwrap();
 
-    let users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
     assert_eq!(users.len(), 1);

--- a/tests/e2e-test/tests/edge_cases/dirty_while_upload.rs
+++ b/tests/e2e-test/tests/edge_cases/dirty_while_upload.rs
@@ -14,6 +14,7 @@ async fn test_upload_insert_and_update_between_retrieve_and_store() {
         username: "user_v1".to_string(),
         first_name: Some("V1".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
     })
     .unwrap();
 
@@ -69,6 +70,7 @@ async fn test_upload_update_and_update_same_column_between_retrieve_and_store() 
             "original".to_string(),
             Some("Original".to_string()),
             carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            carburetor::helpers::get_utc_now(),
             false,
         )
         .await
@@ -85,6 +87,7 @@ async fn test_upload_update_and_update_same_column_between_retrieve_and_store() 
         username: "original".to_string(),
         first_name: Some("Original".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         last_synced_at: Some(before_seed),
         is_deleted: false,
         dirty_flag: None,

--- a/tests/e2e-test/tests/edge_cases/interjecting_download_while_uploading.rs
+++ b/tests/e2e-test/tests/edge_cases/interjecting_download_while_uploading.rs
@@ -17,6 +17,7 @@ async fn test_download_between_upload_process_and_store() {
             "original".to_string(),
             Some("Original".to_string()),
             carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            carburetor::helpers::get_utc_now(),
             false,
         )
         .await
@@ -33,6 +34,7 @@ async fn test_download_between_upload_process_and_store() {
         username: "original".to_string(),
         first_name: Some("Original".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         last_synced_at: Some(before_seed),
         is_deleted: false,
         dirty_flag: None,

--- a/tests/e2e-test/tests/edge_cases/interjecting_download_while_uploading.rs
+++ b/tests/e2e-test/tests/edge_cases/interjecting_download_while_uploading.rs
@@ -1,6 +1,6 @@
 use diesel::{RunQueryDsl, SelectableHelper, query_dsl::methods::SelectDsl};
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::schema::all_clients;
+use sample_test_core::schema::user_only;
 use tarpc::context::current as ctx;
 
 #[tokio::test]
@@ -24,12 +24,11 @@ async fn test_download_between_upload_process_and_store() {
         .unwrap();
 
     let before_seed = backend
-        .test_helper_get_user(ctx(), "user-interject-1".to_string())
+        .test_helper_get_user_last_synced_at(ctx(), "user-interject-1".to_string())
         .await
-        .unwrap()
-        .last_synced_at;
+        .unwrap();
 
-    let synced_user = all_clients::FullUser {
+    let synced_user = user_only::FullUser {
         id: "user-interject-1".to_string(),
         username: "original".to_string(),
         first_name: Some("Original".to_string()),
@@ -40,14 +39,14 @@ async fn test_download_between_upload_process_and_store() {
         dirty_flag: None,
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&synced_user)
         .execute(&mut conn)
         .unwrap();
     carburetor::helpers::carburetor_offset::upsert_offset(&mut conn, "users", before_seed).unwrap();
 
     // Client updates the user — dirty_flag="update"
-    all_clients::update_user(all_clients::UpdateUser {
+    user_only::update_user(user_only::UpdateUser {
         id: "user-interject-1".to_string(),
         username: Some("updated".to_string()),
         first_name: None,
@@ -56,31 +55,31 @@ async fn test_download_between_upload_process_and_store() {
     .unwrap();
 
     // Retrieve upload request
-    let (upload_cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (upload_cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(upload_request.user.len(), 1);
 
     // Backend processes the upload (record is now updated on backend, last_synced_at=T_backend)
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert_eq!(upload_response.user.len(), 1);
     assert!(upload_response.user[0].is_ok());
 
     // --- Interject: download before store_upload_response is called ---
-    let download_request = all_clients::retrieve_download_request().unwrap();
+    let download_request = user_only::retrieve_download_request().unwrap();
     let download_response = backend
-        .process_download_request(ctx(), download_request)
+        .process_user_only_download_request(ctx(), download_request)
         .await
         .unwrap();
     assert_eq! {download_response.user.data.len(), 1};
 
     // Store the download — LWW must not clobber the still-dirty local state
-    all_clients::store_download_response(download_response).unwrap();
+    user_only::store_download_response(download_response).unwrap();
 
     // Verify: dirty_flag is still set because store_upload_response hasn't run yet
-    let users_mid: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let users_mid: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
     assert_eq!(users_mid.len(), 1);
@@ -95,10 +94,10 @@ async fn test_download_between_upload_process_and_store() {
     );
 
     // Now store the upload response — clears the dirty flag
-    all_clients::store_upload_response(upload_cutoff, upload_response).unwrap();
+    user_only::store_upload_response(upload_cutoff, upload_response).unwrap();
 
-    let users_final: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let users_final: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
     assert_eq!(users_final.len(), 1);

--- a/tests/e2e-test/tests/happy_paths/client_operation.rs
+++ b/tests/e2e-test/tests/happy_paths/client_operation.rs
@@ -12,6 +12,7 @@ async fn test_insert_user() {
         username: "test_username".to_string(),
         first_name: Some("John".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
     })
     .unwrap();
 
@@ -81,6 +82,7 @@ async fn test_active_users() {
         username: "active_user".to_string(),
         first_name: Some("Alice".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 3, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         id: "user-active-1".to_string(),
         last_synced_at: None,
         is_deleted: false,
@@ -91,6 +93,7 @@ async fn test_active_users() {
         username: "deleted_user".to_string(),
         first_name: Some("Bob".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 4, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         id: "user-deleted-1".to_string(),
         last_synced_at: None,
         is_deleted: true,
@@ -126,6 +129,7 @@ async fn test_delete_user() {
         username: "test_username".to_string(),
         first_name: Some("John".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         id: "user-test-123".to_string(),
         last_synced_at: None,
         is_deleted: false,
@@ -169,6 +173,7 @@ async fn test_update_user() {
         username: "original_username".to_string(),
         first_name: Some("John".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         id: "user-test-456".to_string(),
         last_synced_at: None,
         is_deleted: false,

--- a/tests/e2e-test/tests/happy_paths/client_operation.rs
+++ b/tests/e2e-test/tests/happy_paths/client_operation.rs
@@ -1,14 +1,14 @@
 use carburetor::chrono::NaiveDate;
 use diesel::{RunQueryDsl, SelectableHelper, query_dsl::methods::SelectDsl};
 use e2e_test::get_clean_test_client_db;
-use sample_test_core::schema::all_clients;
+use sample_test_core::schema::user_only;
 
 #[tokio::test]
 async fn test_insert_user() {
     let mut conn = get_clean_test_client_db().get_connection();
 
     // Insert a user using the generated client function
-    let inserted_user = all_clients::insert_user(all_clients::InsertUser {
+    let inserted_user = user_only::insert_user(user_only::InsertUser {
         username: "test_username".to_string(),
         first_name: Some("John".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
@@ -29,8 +29,8 @@ async fn test_insert_user() {
     assert_eq!(inserted_user.dirty_flag.as_ref().unwrap(), "insert");
 
     // Verify the user exists in the database
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 
@@ -39,7 +39,7 @@ async fn test_insert_user() {
     assert_eq!(stored_users[0].username, "test_username");
 
     // Now update the user and check that dirty_flag remains "insert"
-    let updated_user = all_clients::update_user(all_clients::UpdateUser {
+    let updated_user = user_only::update_user(user_only::UpdateUser {
         username: Some("updated_username".to_string()),
         first_name: Some(Some("Jane".to_string())),
         joined_on: None,
@@ -78,7 +78,7 @@ async fn test_active_users() {
     let mut conn = get_clean_test_client_db().get_connection();
 
     // Insert two users: one active, one soft-deleted
-    let active_user = all_clients::FullUser {
+    let active_user = user_only::FullUser {
         username: "active_user".to_string(),
         first_name: Some("Alice".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 3, 1).unwrap(),
@@ -89,7 +89,7 @@ async fn test_active_users() {
         dirty_flag: None,
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
-    let deleted_user = all_clients::FullUser {
+    let deleted_user = user_only::FullUser {
         username: "deleted_user".to_string(),
         first_name: Some("Bob".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 4, 1).unwrap(),
@@ -100,18 +100,18 @@ async fn test_active_users() {
         dirty_flag: None,
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&active_user)
         .execute(&mut conn)
         .unwrap();
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&deleted_user)
         .execute(&mut conn)
         .unwrap();
 
     // Query active users
-    let active_users: Vec<all_clients::FullUser> = all_clients::active_users()
-        .select(all_clients::FullUser::as_select())
+    let active_users: Vec<user_only::FullUser> = user_only::active_users()
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 
@@ -125,7 +125,7 @@ async fn test_delete_user() {
     let mut conn = get_clean_test_client_db().get_connection();
 
     // First, insert a user directly using diesel
-    let test_user = all_clients::FullUser {
+    let test_user = user_only::FullUser {
         username: "test_username".to_string(),
         first_name: Some("John".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
@@ -137,13 +137,13 @@ async fn test_delete_user() {
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
 
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&test_user)
         .execute(&mut conn)
         .unwrap();
 
     // Delete the user using the generated client function
-    let deleted_user = all_clients::delete_user(test_user.id.clone()).unwrap();
+    let deleted_user = user_only::delete_user(test_user.id.clone()).unwrap();
 
     // Verify the user was marked as deleted
     assert_eq!(deleted_user.id, test_user.id);
@@ -154,8 +154,8 @@ async fn test_delete_user() {
     assert_eq!(deleted_user.dirty_flag.as_ref().unwrap(), "update");
 
     // Verify the user is marked as deleted in the database
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 
@@ -169,7 +169,7 @@ async fn test_update_user() {
     let mut conn = get_clean_test_client_db().get_connection();
 
     // First, insert a user directly using diesel
-    let test_user = all_clients::FullUser {
+    let test_user = user_only::FullUser {
         username: "original_username".to_string(),
         first_name: Some("John".to_string()),
         joined_on: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
@@ -181,13 +181,13 @@ async fn test_update_user() {
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
 
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&test_user)
         .execute(&mut conn)
         .unwrap();
 
     // Update the user using the generated client function
-    let updated_user = all_clients::update_user(all_clients::UpdateUser {
+    let updated_user = user_only::update_user(user_only::UpdateUser {
         username: Some("updated_username".to_string()),
         first_name: Some(Some("Jane".to_string())),
         joined_on: Some(NaiveDate::from_ymd_opt(2025, 2, 1).unwrap()),
@@ -208,8 +208,8 @@ async fn test_update_user() {
     assert_eq!(updated_user.dirty_flag.as_ref().unwrap(), "update");
 
     // Verify the user is updated in the database
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 

--- a/tests/e2e-test/tests/happy_paths/download.rs
+++ b/tests/e2e-test/tests/happy_paths/download.rs
@@ -12,6 +12,7 @@ async fn insert_dummy_user(backend: &TestBackendClient, id: &str, is_deleted: bo
             "username".to_string(),
             None,
             NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            carburetor::helpers::get_utc_now(),
             is_deleted,
         )
         .await

--- a/tests/e2e-test/tests/happy_paths/download.rs
+++ b/tests/e2e-test/tests/happy_paths/download.rs
@@ -1,7 +1,7 @@
 use carburetor::chrono::NaiveDate;
 use diesel::{RunQueryDsl, SelectableHelper, query_dsl::methods::SelectDsl};
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::{backend_service::TestBackendClient, schema::all_clients};
+use sample_test_core::{backend_service::TestBackendClient, schema::user_only};
 use tarpc::context::current as ctx;
 
 async fn insert_dummy_user(backend: &TestBackendClient, id: &str, is_deleted: bool) {
@@ -28,20 +28,26 @@ async fn test_download_from_offset() {
 
     insert_dummy_user(&backend, "a", false).await;
 
-    let req = all_clients::retrieve_download_request().unwrap();
-    let res = backend.process_download_request(ctx(), req).await.unwrap();
+    let req = user_only::retrieve_download_request().unwrap();
+    let res = backend
+        .process_user_only_download_request(ctx(), req)
+        .await
+        .unwrap();
     assert_eq! {res.user.data.len(), 1};
-    all_clients::store_download_response(res).unwrap();
+    user_only::store_download_response(res).unwrap();
 
     insert_dummy_user(&backend, "b", false).await;
 
-    let req = all_clients::retrieve_download_request().unwrap();
-    let res = backend.process_download_request(ctx(), req).await.unwrap();
+    let req = user_only::retrieve_download_request().unwrap();
+    let res = backend
+        .process_user_only_download_request(ctx(), req)
+        .await
+        .unwrap();
     assert_eq! {res.user.data.len(), 1};
-    all_clients::store_download_response(res).unwrap();
+    user_only::store_download_response(res).unwrap();
 
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 
@@ -60,12 +66,15 @@ async fn test_clean_download() {
     insert_dummy_user(&backend, "a", false).await;
     insert_dummy_user(&backend, "b", true).await;
 
-    let req = all_clients::retrieve_download_request().unwrap();
-    let res = backend.process_download_request(ctx(), req).await.unwrap();
+    let req = user_only::retrieve_download_request().unwrap();
+    let res = backend
+        .process_user_only_download_request(ctx(), req)
+        .await
+        .unwrap();
 
-    all_clients::store_download_response(res).unwrap();
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    user_only::store_download_response(res).unwrap();
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 

--- a/tests/e2e-test/tests/happy_paths/download.rs
+++ b/tests/e2e-test/tests/happy_paths/download.rs
@@ -1,8 +1,30 @@
 use carburetor::chrono::NaiveDate;
 use diesel::{RunQueryDsl, SelectableHelper, query_dsl::methods::SelectDsl};
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::{backend_service::TestBackendClient, schema::user_only};
+use sample_test_core::{
+    backend_service::TestBackendClient,
+    schema::{all_clients, user_only},
+};
 use tarpc::context::current as ctx;
+
+async fn insert_dummy_message(
+    backend: &TestBackendClient,
+    id: &str,
+    recipient_id: &str,
+    is_deleted: bool,
+) {
+    backend
+        .test_helper_insert_message(
+            ctx(),
+            id.to_string(),
+            recipient_id.to_string(),
+            "subject".to_string(),
+            "body".to_string(),
+            is_deleted,
+        )
+        .await
+        .unwrap();
+}
 
 async fn insert_dummy_user(backend: &TestBackendClient, id: &str, is_deleted: bool) {
     backend
@@ -80,4 +102,34 @@ async fn test_clean_download() {
 
     assert_eq!(stored_users.len(), 1);
     assert_eq!(stored_users[0].id, "a".to_string());
+}
+
+
+#[tokio::test]
+async fn test_download_only_returns_messages_matching_context() {
+    get_clean_test_client_db();
+
+    let backend_server = TestBackendHandle::start();
+    let backend = backend_server.client().await;
+
+    insert_dummy_message(&backend, "msg-a", "user-1", false).await;
+    insert_dummy_message(&backend, "msg-b", "user-2", false).await;
+    insert_dummy_message(&backend, "msg-c", "user-1", false).await;
+
+    let req = all_clients::retrieve_download_request().unwrap();
+    let res = backend
+        .process_all_clients_download_request(ctx(), req, "user-1".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(res.message.data.len(), 2);
+    assert!(res.message.data.iter().any(
+        |m| matches!(m, carburetor::models::DownloadTableResponseData::Update(u) if u.id == "msg-a")
+    ));
+    assert!(res.message.data.iter().any(
+        |m| matches!(m, carburetor::models::DownloadTableResponseData::Update(u) if u.id == "msg-c")
+    ));
+    assert!(!res.message.data.iter().any(
+        |m| matches!(m, carburetor::models::DownloadTableResponseData::Update(u) if u.id == "msg-b")
+    ));
 }

--- a/tests/e2e-test/tests/happy_paths/sync.rs
+++ b/tests/e2e-test/tests/happy_paths/sync.rs
@@ -14,6 +14,7 @@ async fn test_upload_insert_then_download() {
         username: "sync_user".to_string(),
         first_name: Some("SyncUser".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 8, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
     })
     .unwrap();
 
@@ -75,6 +76,7 @@ async fn test_upload_update_then_download() {
             "original_user".to_string(),
             Some("OriginalUser".to_string()),
             carburetor::chrono::NaiveDate::from_ymd_opt(2025, 9, 1).unwrap(),
+            carburetor::helpers::get_utc_now(),
             false,
         )
         .await
@@ -92,6 +94,7 @@ async fn test_upload_update_then_download() {
         username: "original_user".to_string(),
         first_name: Some("OriginalUser".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 9, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         last_synced_at: Some(before_insert),
         is_deleted: false,
         dirty_flag: None,

--- a/tests/e2e-test/tests/happy_paths/sync.rs
+++ b/tests/e2e-test/tests/happy_paths/sync.rs
@@ -1,6 +1,6 @@
 use diesel::{QueryDsl, RunQueryDsl, SelectableHelper};
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::schema::all_clients;
+use sample_test_core::schema::user_only;
 use tarpc::context::current as ctx;
 
 #[tokio::test]
@@ -10,7 +10,7 @@ async fn test_upload_insert_then_download() {
     let backend = backend_server.client().await;
 
     // Insert a user on client using the generated function
-    let inserted_user = all_clients::insert_user(all_clients::InsertUser {
+    let inserted_user = user_only::insert_user(user_only::InsertUser {
         username: "sync_user".to_string(),
         first_name: Some("SyncUser".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 8, 1).unwrap(),
@@ -19,37 +19,37 @@ async fn test_upload_insert_then_download() {
     .unwrap();
 
     // Upload the dirty record to backend
-    let (upload_cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (upload_cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(upload_request.user.len(), 1);
 
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert_eq!(upload_response.user.len(), 1);
 
-    all_clients::store_upload_response(upload_cutoff, upload_response).unwrap();
+    user_only::store_upload_response(upload_cutoff, upload_response).unwrap();
 
     // Verify dirty flag is cleared
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
     assert_eq!(stored_users.len(), 1);
     assert_eq!(stored_users[0].dirty_flag, None);
 
-    let download_request = all_clients::retrieve_download_request().unwrap();
+    let download_request = user_only::retrieve_download_request().unwrap();
     let download_response = backend
-        .process_download_request(ctx(), download_request)
+        .process_user_only_download_request(ctx(), download_request)
         .await
         .unwrap();
     assert_eq! {download_response.user.data.len(), 1};
 
-    all_clients::store_download_response(download_response).unwrap();
+    user_only::store_download_response(download_response).unwrap();
 
     // Verify the record was properly merged and last_synced_at is now set
-    let final_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let final_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
     assert_eq!(final_users.len(), 1);
@@ -83,13 +83,12 @@ async fn test_upload_update_then_download() {
         .unwrap();
 
     let before_insert = backend
-        .test_helper_get_user(ctx(), "user-sync-2".to_string())
+        .test_helper_get_user_last_synced_at(ctx(), "user-sync-2".to_string())
         .await
-        .unwrap()
-        .last_synced_at;
+        .unwrap();
 
     // Seed the client with the user as if it was already downloaded (record + offset)
-    let synced_user = all_clients::FullUser {
+    let synced_user = user_only::FullUser {
         id: "user-sync-2".to_string(),
         username: "original_user".to_string(),
         first_name: Some("OriginalUser".to_string()),
@@ -100,7 +99,7 @@ async fn test_upload_update_then_download() {
         dirty_flag: None,
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&synced_user)
         .execute(&mut conn)
         .unwrap();
@@ -109,7 +108,7 @@ async fn test_upload_update_then_download() {
         .unwrap();
 
     // Update the user on the client using the generated function
-    let updated_user = all_clients::update_user(all_clients::UpdateUser {
+    let updated_user = user_only::update_user(user_only::UpdateUser {
         id: "user-sync-2".to_string(),
         username: Some("updated_user".to_string()),
         first_name: Some(Some("UpdatedUser".to_string())),
@@ -119,29 +118,29 @@ async fn test_upload_update_then_download() {
     assert_eq!(updated_user.dirty_flag.as_deref(), Some("update"));
 
     // Upload the dirty update to backend
-    let (upload_cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (upload_cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(upload_request.user.len(), 1);
 
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert_eq!(upload_response.user.len(), 1);
 
-    all_clients::store_upload_response(upload_cutoff, upload_response).unwrap();
+    user_only::store_upload_response(upload_cutoff, upload_response).unwrap();
 
-    let download_request = all_clients::retrieve_download_request().unwrap();
+    let download_request = user_only::retrieve_download_request().unwrap();
     let download_response = backend
-        .process_download_request(ctx(), download_request)
+        .process_user_only_download_request(ctx(), download_request)
         .await
         .unwrap();
     assert_eq! {download_response.user.data.len(), 1};
 
-    all_clients::store_download_response(download_response).unwrap();
+    user_only::store_download_response(download_response).unwrap();
 
     // Verify the record was properly merged and last_synced_at is updated
-    let final_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let final_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
     assert_eq!(final_users.len(), 1);

--- a/tests/e2e-test/tests/happy_paths/upload.rs
+++ b/tests/e2e-test/tests/happy_paths/upload.rs
@@ -1,7 +1,7 @@
 use carburetor::helpers::client_sync_metadata::ClientSyncMetadata;
 use diesel::{RunQueryDsl, SelectableHelper, query_dsl::methods::SelectDsl};
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::schema::user_only;
+use sample_test_core::schema::{all_clients, user_only};
 use tarpc::context::current as ctx;
 
 #[tokio::test]
@@ -266,4 +266,120 @@ async fn test_upload_with_updated_dirty_record() {
             .column_last_synced_at
             .is_some()
     );
+}
+
+#[tokio::test]
+async fn test_upload_update_message_matching_context() {
+    let mut conn = get_clean_test_client_db().get_connection();
+
+    let backend_server = TestBackendHandle::start();
+    let backend = backend_server.client().await;
+
+    backend
+        .test_helper_insert_message(
+            ctx(),
+            "msg-update-1".to_string(),
+            "user-1".to_string(),
+            "Hello".to_string(),
+            "World".to_string(),
+            false,
+        )
+        .await
+        .unwrap();
+
+    let dirty_at = carburetor::helpers::get_utc_now().to_rfc3339();
+
+    let dirty_message = all_clients::FullMessage {
+        id: "msg-update-1".to_string(),
+        recipient_id: "user-1".to_string(),
+        subject: "Updated Subject".to_string(),
+        body: "Updated Body".to_string(),
+        last_synced_at: None,
+        is_deleted: false,
+        dirty_flag: Some("update".to_string()),
+        column_sync_metadata: carburetor::serde_json::from_str(&format!(
+            r#"{{"subject": {{"dirty_at": "{}"}}, "body": {{"dirty_at": "{}"}}}}"#,
+            dirty_at, dirty_at
+        ))
+        .unwrap(),
+    };
+    diesel::insert_into(all_clients::messages::table)
+        .values(&dirty_message)
+        .execute(&mut conn)
+        .unwrap();
+
+    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    assert_eq!(upload_request.message.len(), 1);
+
+    let upload_response = backend
+        .process_all_clients_upload_request(ctx(), upload_request, "user-1".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(upload_response.message.len(), 1);
+    match &upload_response.message[0] {
+        Ok(r) => assert_eq!(r.id, dirty_message.id),
+        Err(e) => panic!("Expected success, got error: {:?}", e),
+    }
+
+    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+
+    let stored: Vec<all_clients::FullMessage> = all_clients::messages::table
+        .select(all_clients::FullMessage::as_select())
+        .load(&mut conn)
+        .unwrap();
+
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].dirty_flag, None);
+}
+
+#[tokio::test]
+async fn test_upload_insert_message_matching_context() {
+    let mut conn = get_clean_test_client_db().get_connection();
+
+    let backend_server = TestBackendHandle::start();
+    let backend = backend_server.client().await;
+
+    let dirty_message = all_clients::FullMessage {
+        id: "msg-insert-1".to_string(),
+        recipient_id: "user-1".to_string(),
+        subject: "Hello".to_string(),
+        body: "World".to_string(),
+        last_synced_at: None,
+        is_deleted: false,
+        dirty_flag: Some("insert".to_string()),
+        column_sync_metadata: carburetor::serde_json::from_str(&format!(
+            r#"{{".insert_time": "{}"}}"#,
+            carburetor::helpers::get_utc_now().to_rfc3339()
+        ))
+        .unwrap(),
+    };
+    diesel::insert_into(all_clients::messages::table)
+        .values(&dirty_message)
+        .execute(&mut conn)
+        .unwrap();
+
+    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    assert_eq!(upload_request.message.len(), 1);
+
+    let upload_response = backend
+        .process_all_clients_upload_request(ctx(), upload_request, "user-1".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(upload_response.message.len(), 1);
+    match &upload_response.message[0] {
+        Ok(r) => assert_eq!(r.id, dirty_message.id),
+        Err(e) => panic!("Expected success, got error: {:?}", e),
+    }
+
+    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+
+    let stored: Vec<all_clients::FullMessage> = all_clients::messages::table
+        .select(all_clients::FullMessage::as_select())
+        .load(&mut conn)
+        .unwrap();
+
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].dirty_flag, None);
 }

--- a/tests/e2e-test/tests/happy_paths/upload.rs
+++ b/tests/e2e-test/tests/happy_paths/upload.rs
@@ -15,6 +15,7 @@ async fn test_upload_with_no_dirty_record() {
         username: "clean_user".to_string(),
         first_name: Some("NoDirty".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 5, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         id: "user-clean-1".to_string(),
         last_synced_at: None,
         is_deleted: false,
@@ -58,6 +59,7 @@ async fn test_upload_with_inserted_dirty_record() {
         username: "new_user".to_string(),
         first_name: Some("NewUser".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 6, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         id: "user-insert-1".to_string(),
         last_synced_at: None,
         is_deleted: false,
@@ -145,6 +147,7 @@ async fn test_upload_with_updated_dirty_record() {
             "original_user".to_string(),
             Some("OriginalUser".to_string()),
             carburetor::chrono::NaiveDate::from_ymd_opt(2025, 7, 1).unwrap(),
+            carburetor::helpers::get_utc_now(),
             false,
         )
         .await
@@ -157,6 +160,7 @@ async fn test_upload_with_updated_dirty_record() {
         username: "updated_user".to_string(),
         first_name: Some("UpdatedUser".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 7, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         id: "user-update-1".to_string(),
         last_synced_at: None,
         is_deleted: false,

--- a/tests/e2e-test/tests/happy_paths/upload.rs
+++ b/tests/e2e-test/tests/happy_paths/upload.rs
@@ -1,7 +1,7 @@
 use carburetor::helpers::client_sync_metadata::ClientSyncMetadata;
 use diesel::{RunQueryDsl, SelectableHelper, query_dsl::methods::SelectDsl};
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::schema::all_clients;
+use sample_test_core::schema::user_only;
 use tarpc::context::current as ctx;
 
 #[tokio::test]
@@ -11,7 +11,7 @@ async fn test_upload_with_no_dirty_record() {
     let backend = backend_server.client().await;
 
     // Insert a clean (non-dirty) user record
-    let clean_user = all_clients::FullUser {
+    let clean_user = user_only::FullUser {
         username: "clean_user".to_string(),
         first_name: Some("NoDirty".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 5, 1).unwrap(),
@@ -22,13 +22,13 @@ async fn test_upload_with_no_dirty_record() {
         dirty_flag: None,
         column_sync_metadata: carburetor::serde_json::from_str("{}").unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&clean_user)
         .execute(&mut conn)
         .unwrap();
 
     // Retrieve upload request
-    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert!(
         upload_request.user.is_empty(),
         "No dirty records should be present, even if clean records exist"
@@ -36,7 +36,7 @@ async fn test_upload_with_no_dirty_record() {
 
     // Send to backend and get response
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert!(
@@ -45,7 +45,7 @@ async fn test_upload_with_no_dirty_record() {
     );
 
     // Store upload response (should be a no-op, but should not error)
-    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+    user_only::store_upload_response(cutoff, upload_response).unwrap();
 }
 
 #[tokio::test]
@@ -55,7 +55,7 @@ async fn test_upload_with_inserted_dirty_record() {
     let backend = backend_server.client().await;
 
     // Insert a user with dirty flag set to "insert"
-    let dirty_user = all_clients::FullUser {
+    let dirty_user = user_only::FullUser {
         username: "new_user".to_string(),
         first_name: Some("NewUser".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 6, 1).unwrap(),
@@ -70,13 +70,13 @@ async fn test_upload_with_inserted_dirty_record() {
         ))
         .unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&dirty_user)
         .execute(&mut conn)
         .unwrap();
 
     // Retrieve upload request
-    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(
         upload_request.user.len(),
         1,
@@ -85,7 +85,7 @@ async fn test_upload_with_inserted_dirty_record() {
 
     // Verify the upload request contains the inserted user
     match &upload_request.user[0] {
-        all_clients::UploadRequestUser::Insert(insert_data) => {
+        user_only::UploadRequestUser::Insert(insert_data) => {
             assert_eq!(insert_data.id, dirty_user.id);
             assert_eq!(insert_data.username, "new_user");
             assert_eq!(insert_data.first_name, Some("NewUser".to_string()));
@@ -96,7 +96,7 @@ async fn test_upload_with_inserted_dirty_record() {
 
     // Send to backend and get response
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert_eq!(
@@ -114,11 +114,11 @@ async fn test_upload_with_inserted_dirty_record() {
     }
 
     // Store upload response (should clear dirty flag)
-    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+    user_only::store_upload_response(cutoff, upload_response).unwrap();
 
     // Verify dirty flag is cleared
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 
@@ -128,7 +128,7 @@ async fn test_upload_with_inserted_dirty_record() {
         stored_users[0].dirty_flag, None,
         "Dirty flag should be cleared after successful upload"
     );
-    let metadata: ClientSyncMetadata<all_clients::UserSyncMetadata> =
+    let metadata: ClientSyncMetadata<user_only::UserSyncMetadata> =
         carburetor::serde_json::from_value(stored_users[0].column_sync_metadata.clone()).unwrap();
     assert_eq!(metadata.insert_time, None);
 }
@@ -156,7 +156,7 @@ async fn test_upload_with_updated_dirty_record() {
     let dirty_at = carburetor::helpers::get_utc_now().to_rfc3339();
 
     // Insert a user with dirty flag set to "update" with column-level metadata
-    let dirty_user = all_clients::FullUser {
+    let dirty_user = user_only::FullUser {
         username: "updated_user".to_string(),
         first_name: Some("UpdatedUser".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 7, 1).unwrap(),
@@ -174,13 +174,13 @@ async fn test_upload_with_updated_dirty_record() {
         ))
         .unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&dirty_user)
         .execute(&mut conn)
         .unwrap();
 
     // Retrieve upload request
-    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(
         upload_request.user.len(),
         1,
@@ -189,7 +189,7 @@ async fn test_upload_with_updated_dirty_record() {
 
     // Verify the upload request contains the updated user
     match &upload_request.user[0] {
-        all_clients::UploadRequestUser::Update(update_data) => {
+        user_only::UploadRequestUser::Update(update_data) => {
             assert_eq!(update_data.id, dirty_user.id);
             assert_eq!(update_data.username, Some("updated_user".to_string()));
             assert_eq!(
@@ -204,7 +204,7 @@ async fn test_upload_with_updated_dirty_record() {
 
     // Send to backend and get response
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
     assert_eq!(
@@ -222,11 +222,11 @@ async fn test_upload_with_updated_dirty_record() {
     }
 
     // Store upload response (should clear dirty flag)
-    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+    user_only::store_upload_response(cutoff, upload_response).unwrap();
 
     // Verify dirty flag is cleared
-    let stored_users: Vec<all_clients::FullUser> = all_clients::users::table
-        .select(all_clients::FullUser::as_select())
+    let stored_users: Vec<user_only::FullUser> = user_only::users::table
+        .select(user_only::FullUser::as_select())
         .load(&mut conn)
         .unwrap();
 
@@ -236,7 +236,7 @@ async fn test_upload_with_updated_dirty_record() {
         stored_users[0].dirty_flag, None,
         "Dirty flag should be cleared after successful upload"
     );
-    let metadata: ClientSyncMetadata<all_clients::UserSyncMetadata> =
+    let metadata: ClientSyncMetadata<user_only::UserSyncMetadata> =
         carburetor::serde_json::from_value(stored_users[0].column_sync_metadata.clone()).unwrap();
     assert_eq!(
         metadata.clone().data.unwrap().username.unwrap().dirty_at,

--- a/tests/e2e-test/tests/unhappy_paths/backend.rs
+++ b/tests/e2e-test/tests/unhappy_paths/backend.rs
@@ -1,7 +1,7 @@
 use carburetor::models::UploadTableResponseErrorType;
 use diesel::RunQueryDsl;
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::schema::user_only;
+use sample_test_core::schema::{all_clients, user_only};
 use tarpc::context::current as ctx;
 
 #[tokio::test]
@@ -112,4 +112,105 @@ async fn test_upload_insert_record_already_exists_on_backend() {
     }
 
     user_only::store_upload_response(cutoff, upload_response).unwrap();
+}
+
+#[tokio::test]
+async fn test_upload_insert_message_mismatching_context() {
+    let mut conn = get_clean_test_client_db().get_connection();
+
+    let backend_server = TestBackendHandle::start();
+    let backend = backend_server.client().await;
+
+    let dirty_message = all_clients::FullMessage {
+        id: "msg-reject-1".to_string(),
+        recipient_id: "user-1".to_string(),
+        subject: "Hello".to_string(),
+        body: "World".to_string(),
+        last_synced_at: None,
+        is_deleted: false,
+        dirty_flag: Some("insert".to_string()),
+        column_sync_metadata: carburetor::serde_json::from_str(&format!(
+            r#"{{".insert_time": "{}"}}"#,
+            carburetor::helpers::get_utc_now().to_rfc3339()
+        ))
+        .unwrap(),
+    };
+    diesel::insert_into(all_clients::messages::table)
+        .values(&dirty_message)
+        .execute(&mut conn)
+        .unwrap();
+
+    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let upload_response = backend
+        .process_all_clients_upload_request(ctx(), upload_request, "user-2".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(upload_response.message.len(), 1);
+    match &upload_response.message[0] {
+        Err(e) => {
+            assert_eq!(e.id, dirty_message.id);
+            assert_eq!(e.code, UploadTableResponseErrorType::InsufficientPermission);
+        }
+        Ok(_) => panic!("Expected rejection for mismatched context"),
+    }
+
+    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+}
+
+#[tokio::test]
+async fn test_upload_update_message_mismatching_context() {
+    let mut conn = get_clean_test_client_db().get_connection();
+
+    let backend_server = TestBackendHandle::start();
+    let backend = backend_server.client().await;
+
+    backend
+        .test_helper_insert_message(
+            ctx(),
+            "msg-update-reject-1".to_string(),
+            "user-1".to_string(),
+            "subject".to_string(),
+            "body".to_string(),
+            false,
+        )
+        .await
+        .unwrap();
+
+    let dirty_at = carburetor::helpers::get_utc_now().to_rfc3339();
+    let dirty_message = all_clients::FullMessage {
+        id: "msg-update-reject-1".to_string(),
+        recipient_id: "user-1".to_string(),
+        subject: "Updated subject".to_string(),
+        body: "Updated body".to_string(),
+        last_synced_at: None,
+        is_deleted: false,
+        dirty_flag: Some("update".to_string()),
+        column_sync_metadata: carburetor::serde_json::from_str(&format!(
+            r#"{{"subject": {{"dirty_at": "{}"}}, "body": {{"dirty_at": "{}"}}}}"#,
+            dirty_at, dirty_at
+        ))
+        .unwrap(),
+    };
+    diesel::insert_into(all_clients::messages::table)
+        .values(&dirty_message)
+        .execute(&mut conn)
+        .unwrap();
+
+    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let upload_response = backend
+        .process_all_clients_upload_request(ctx(), upload_request, "user-2".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(upload_response.message.len(), 1);
+    match &upload_response.message[0] {
+        Err(e) => {
+            assert_eq!(e.id, dirty_message.id);
+            assert_eq!(e.code, UploadTableResponseErrorType::InsufficientPermission);
+        }
+        Ok(_) => panic!("Expected rejection for mismatched context on update"),
+    }
+
+    all_clients::store_upload_response(cutoff, upload_response).unwrap();
 }

--- a/tests/e2e-test/tests/unhappy_paths/backend.rs
+++ b/tests/e2e-test/tests/unhappy_paths/backend.rs
@@ -1,7 +1,7 @@
 use carburetor::models::UploadTableResponseErrorType;
 use diesel::RunQueryDsl;
 use e2e_test::{TestBackendHandle, get_clean_test_client_db};
-use sample_test_core::schema::all_clients;
+use sample_test_core::schema::user_only;
 use tarpc::context::current as ctx;
 
 #[tokio::test]
@@ -13,7 +13,7 @@ async fn test_upload_update_record_not_on_backend() {
     let dirty_at = carburetor::helpers::get_utc_now().to_rfc3339();
 
     // Insert a local record with dirty_flag = "update" but it doesn't exist on backend
-    let dirty_user = all_clients::FullUser {
+    let dirty_user = user_only::FullUser {
         id: "user-nonexistent-1".to_string(),
         username: "ghost_user".to_string(),
         first_name: Some("Ghost".to_string()),
@@ -28,16 +28,16 @@ async fn test_upload_update_record_not_on_backend() {
         ))
         .unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&dirty_user)
         .execute(&mut conn)
         .unwrap();
 
-    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(upload_request.user.len(), 1);
 
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
 
@@ -50,7 +50,7 @@ async fn test_upload_update_record_not_on_backend() {
         Ok(_) => panic!("Expected error for updating non-existent backend record"),
     }
 
-    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+    user_only::store_upload_response(cutoff, upload_response).unwrap();
 }
 
 #[tokio::test]
@@ -74,7 +74,7 @@ async fn test_upload_insert_record_already_exists_on_backend() {
         .unwrap();
 
     // Now try to insert the same record from client
-    let dirty_user = all_clients::FullUser {
+    let dirty_user = user_only::FullUser {
         id: "user-duplicate-1".to_string(),
         username: "existing_user".to_string(),
         first_name: Some("Existing".to_string()),
@@ -89,16 +89,16 @@ async fn test_upload_insert_record_already_exists_on_backend() {
         ))
         .unwrap(),
     };
-    diesel::insert_into(all_clients::users::table)
+    diesel::insert_into(user_only::users::table)
         .values(&dirty_user)
         .execute(&mut conn)
         .unwrap();
 
-    let (cutoff, upload_request) = all_clients::retrieve_upload_request().unwrap();
+    let (cutoff, upload_request) = user_only::retrieve_upload_request().unwrap();
     assert_eq!(upload_request.user.len(), 1);
 
     let upload_response = backend
-        .process_upload_request(ctx(), upload_request)
+        .process_user_only_upload_request(ctx(), upload_request)
         .await
         .unwrap();
 
@@ -111,5 +111,5 @@ async fn test_upload_insert_record_already_exists_on_backend() {
         Ok(_) => panic!("Expected error for inserting already-existing backend record"),
     }
 
-    all_clients::store_upload_response(cutoff, upload_response).unwrap();
+    user_only::store_upload_response(cutoff, upload_response).unwrap();
 }

--- a/tests/e2e-test/tests/unhappy_paths/backend.rs
+++ b/tests/e2e-test/tests/unhappy_paths/backend.rs
@@ -18,6 +18,7 @@ async fn test_upload_update_record_not_on_backend() {
         username: "ghost_user".to_string(),
         first_name: Some("Ghost".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         last_synced_at: None,
         is_deleted: false,
         dirty_flag: Some("update".to_string()),
@@ -66,6 +67,7 @@ async fn test_upload_insert_record_already_exists_on_backend() {
             "existing_user".to_string(),
             Some("Existing".to_string()),
             carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            carburetor::helpers::get_utc_now(),
             false,
         )
         .await
@@ -77,6 +79,7 @@ async fn test_upload_insert_record_already_exists_on_backend() {
         username: "existing_user".to_string(),
         first_name: Some("Existing".to_string()),
         joined_on: carburetor::chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        created_at: carburetor::helpers::get_utc_now(),
         last_synced_at: None,
         is_deleted: false,
         dirty_flag: Some("insert".to_string()),

--- a/tests/sample-test-backend/src/test_database.rs
+++ b/tests/sample-test-backend/src/test_database.rs
@@ -62,5 +62,18 @@ impl TestDatabase {
         )
         .execute(conn)
         .expect("Failed to create users table");
+
+        diesel::sql_query(
+            "CREATE TABLE messages(
+                id TEXT PRIMARY KEY,
+                recipient_id TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                body TEXT NOT NULL,
+                last_synced_at TIMESTAMPTZ,
+                is_deleted BOOLEAN
+            )",
+        )
+        .execute(conn)
+        .expect("Failed to create messages table");
     }
 }

--- a/tests/sample-test-backend/src/test_database.rs
+++ b/tests/sample-test-backend/src/test_database.rs
@@ -55,6 +55,7 @@ impl TestDatabase {
                 username TEXT NOT NULL,
                 first_name TEXT,
                 joined_on DATE,
+                created_at TIMESTAMPTZ NOT NULL,
                 last_synced_at TIMESTAMPTZ,
                 is_deleted BOOLEAN
             )",

--- a/tests/sample-test-backend/src/test_service.rs
+++ b/tests/sample-test-backend/src/test_service.rs
@@ -1,5 +1,5 @@
 use carburetor::{
-    chrono::NaiveDate,
+    chrono::{DateTimeUtc, NaiveDate},
     helpers::{get_connection, get_db_utc_now},
 };
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, dsl::insert_into};
@@ -83,6 +83,7 @@ impl TestBackend for TestService {
         username: String,
         first_name: Option<String>,
         joined_on: NaiveDate,
+        created_at: DateTimeUtc,
         is_deleted: bool,
     ) {
         let mut conn = get_connection().unwrap();
@@ -94,6 +95,7 @@ impl TestBackend for TestService {
                     username,
                     first_name,
                     joined_on,
+                    created_at,
                     is_deleted,
                 },
                 schema::users::last_synced_at.eq(utc_now),

--- a/tests/sample-test-backend/src/test_service.rs
+++ b/tests/sample-test-backend/src/test_service.rs
@@ -6,7 +6,7 @@ use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, dsl::insert_into};
 use futures::StreamExt;
 use sample_test_core::{
     backend_service::TestBackend,
-    schema::{self, all_clients},
+    schema::{self, user_only},
 };
 use tarpc::{context::Context, server::Channel};
 use tokio::signal::unix::{SignalKind, signal};
@@ -60,20 +60,20 @@ impl TestService {
 }
 
 impl TestBackend for TestService {
-    async fn process_download_request(
+    async fn process_user_only_download_request(
         self,
         _: Context,
-        request: Option<all_clients::DownloadRequest>,
-    ) -> all_clients::DownloadResponse {
-        all_clients::process_download_request(request).unwrap()
+        request: Option<user_only::DownloadRequest>,
+    ) -> user_only::DownloadResponse {
+        user_only::process_download_request(request).unwrap()
     }
 
-    async fn process_upload_request(
+    async fn process_user_only_upload_request(
         self,
         _: Context,
-        request: all_clients::UploadRequest,
-    ) -> all_clients::UploadResponse {
-        all_clients::process_upload_request(request).unwrap()
+        request: user_only::UploadRequest,
+    ) -> user_only::UploadResponse {
+        user_only::process_upload_request(request).unwrap()
     }
 
     async fn test_helper_insert_user(
@@ -104,11 +104,10 @@ impl TestBackend for TestService {
             .unwrap();
     }
 
-    async fn test_helper_get_user(self, _: Context, id: String) -> all_clients::DownloadUpdateUser {
-        use diesel::SelectableHelper;
+    async fn test_helper_get_user_last_synced_at(self, _: Context, id: String) -> DateTimeUtc {
         schema::users::table
             .find(&id)
-            .select(all_clients::DownloadUpdateUser::as_select())
+            .select(schema::users::last_synced_at)
             .first(&mut get_connection().unwrap())
             .unwrap()
     }

--- a/tests/sample-test-backend/src/test_service.rs
+++ b/tests/sample-test-backend/src/test_service.rs
@@ -6,7 +6,7 @@ use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, dsl::insert_into};
 use futures::StreamExt;
 use sample_test_core::{
     backend_service::TestBackend,
-    schema::{self, user_only},
+    schema::{self, all_clients, user_only},
 };
 use tarpc::{context::Context, server::Channel};
 use tokio::signal::unix::{SignalKind, signal};
@@ -76,6 +76,30 @@ impl TestBackend for TestService {
         user_only::process_upload_request(request).unwrap()
     }
 
+    async fn process_all_clients_download_request(
+        self,
+        _: Context,
+        request: Option<all_clients::DownloadRequest>,
+        context_user_id: String,
+    ) -> all_clients::DownloadResponse {
+        let context = all_clients::SyncContext {
+            user_id: context_user_id,
+        };
+        all_clients::process_download_request(request, &context).unwrap()
+    }
+
+    async fn process_all_clients_upload_request(
+        self,
+        _: Context,
+        request: all_clients::UploadRequest,
+        context_user_id: String,
+    ) -> all_clients::UploadResponse {
+        let context = all_clients::SyncContext {
+            user_id: context_user_id,
+        };
+        all_clients::process_upload_request(request, &context).unwrap()
+    }
+
     async fn test_helper_insert_user(
         self,
         _: Context,
@@ -99,6 +123,32 @@ impl TestBackend for TestService {
                     is_deleted,
                 },
                 schema::users::last_synced_at.eq(utc_now),
+            ))
+            .execute(&mut get_connection().unwrap())
+            .unwrap();
+    }
+
+    async fn test_helper_insert_message(
+        self,
+        _: Context,
+        id: String,
+        recipient_id: String,
+        subject: String,
+        body: String,
+        is_deleted: bool,
+    ) {
+        let mut conn = get_connection().unwrap();
+        let utc_now = get_db_utc_now(&mut conn).unwrap();
+        insert_into(schema::messages::table)
+            .values((
+                schema::InsertMessage {
+                    id,
+                    recipient_id,
+                    subject,
+                    body,
+                    is_deleted,
+                },
+                schema::messages::last_synced_at.eq(utc_now),
             ))
             .execute(&mut get_connection().unwrap())
             .unwrap();

--- a/tests/sample-test-core/src/lib.rs
+++ b/tests/sample-test-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod backend_service {
             username: String,
             first_name: Option<String>,
             joined_on: NaiveDate,
+            created_at: carburetor::chrono::DateTimeUtc,
             is_deleted: bool,
         );
         async fn test_helper_get_user(id: String) -> all_clients::DownloadUpdateUser;
@@ -32,6 +33,8 @@ pub mod schema {
                 username -> Text,
                 first_name -> Nullable<Text>,
                 joined_on -> Date,
+                #[immutable]
+                created_at -> Timestamptz,
             }
         }
         sync_groups {

--- a/tests/sample-test-core/src/lib.rs
+++ b/tests/sample-test-core/src/lib.rs
@@ -1,15 +1,17 @@
 pub mod backend_service {
-    use carburetor::chrono::NaiveDate;
+    use carburetor::chrono::{DateTimeUtc, NaiveDate};
 
-    use crate::schema::all_clients::{
-        self, DownloadRequest, DownloadResponse, UploadRequest, UploadResponse,
-    };
+    use crate::schema::user_only;
 
     #[tarpc::service]
     pub trait TestBackend {
         // Backend functions
-        async fn process_download_request(request: Option<DownloadRequest>) -> DownloadResponse;
-        async fn process_upload_request(request: UploadRequest) -> UploadResponse;
+        async fn process_user_only_download_request(
+            request: Option<user_only::DownloadRequest>,
+        ) -> user_only::DownloadResponse;
+        async fn process_user_only_upload_request(
+            request: user_only::UploadRequest,
+        ) -> user_only::UploadResponse;
 
         // Test helper functions
         async fn test_helper_insert_user(
@@ -17,10 +19,10 @@ pub mod backend_service {
             username: String,
             first_name: Option<String>,
             joined_on: NaiveDate,
-            created_at: carburetor::chrono::DateTimeUtc,
+            created_at: DateTimeUtc,
             is_deleted: bool,
         );
-        async fn test_helper_get_user(id: String) -> all_clients::DownloadUpdateUser;
+        async fn test_helper_get_user_last_synced_at(id: String) -> DateTimeUtc;
     }
 }
 
@@ -38,7 +40,7 @@ pub mod schema {
             }
         }
         sync_groups {
-            all_clients {
+            user_only {
                 user
             }
         }

--- a/tests/sample-test-core/src/lib.rs
+++ b/tests/sample-test-core/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod backend_service {
     use carburetor::chrono::{DateTimeUtc, NaiveDate};
 
-    use crate::schema::user_only;
+    use crate::schema::{all_clients, user_only};
 
     #[tarpc::service]
     pub trait TestBackend {
@@ -12,6 +12,14 @@ pub mod backend_service {
         async fn process_user_only_upload_request(
             request: user_only::UploadRequest,
         ) -> user_only::UploadResponse;
+        async fn process_all_clients_download_request(
+            request: Option<all_clients::DownloadRequest>,
+            context_user_id: String,
+        ) -> all_clients::DownloadResponse;
+        async fn process_all_clients_upload_request(
+            request: all_clients::UploadRequest,
+            context_user_id: String,
+        ) -> all_clients::UploadResponse;
 
         // Test helper functions
         async fn test_helper_insert_user(
@@ -20,6 +28,13 @@ pub mod backend_service {
             first_name: Option<String>,
             joined_on: NaiveDate,
             created_at: DateTimeUtc,
+            is_deleted: bool,
+        );
+        async fn test_helper_insert_message(
+            id: String,
+            recipient_id: String,
+            subject: String,
+            body: String,
             is_deleted: bool,
         );
         async fn test_helper_get_user_last_synced_at(id: String) -> DateTimeUtc;
@@ -38,10 +53,23 @@ pub mod schema {
                 #[immutable]
                 created_at -> Timestamptz,
             }
+            message {
+                #[immutable]
+                recipient_id -> Text,
+                subject -> Text,
+                body -> Text,
+            }
         }
         sync_groups {
             user_only {
                 user
+            }
+            all_clients {
+                user,
+                message(
+                    restrict_to = $user_id,
+                    restrict_to_column = recipient_id,
+                )
             }
         }
     }


### PR DESCRIPTION
### Summary
Introduces row-level access control to sync groups via `restrict_to` / `restrict_to_column` attributes, and column-level immutability via the `#[immutable]` attribute. Together, these enable per-user data isolation and protection of write-once fields throughout the sync lifecycle.

### Changes
- **`#[immutable]` column attribute** — Marks a data column as read-only after initial creation. Immutable columns are excluded from the generated `AsChangeset` / `UpdateModel` types, so they can never be overwritten by an incoming sync update. Applying `#[immutable]` to a special column (`#[id]`, `#[last_synced_at]`, etc.) is a compile-time error.

- **`restrict_to` / `restrict_to_column` sync group attributes** — When both are set on a table entry inside a sync group, the macro generates a `SyncContext` struct for that group. At runtime, `process_download_request` and `process_upload_request` accept this context and filter / validate rows accordingly:
  - **Download**: adds a `WHERE <column> = context.<field>` filter to the query.
  - **Upload**: validates that the restricted column in every incoming insert or update matches the context value; rejects mismatches with a new `InsufficientPermission` error code.

- **Parser changes** — Sync group table entries are now parsed as `DeclarationSettingBlock` (ident + optional arguments) instead of bare `Ident`, enabling key-value arguments. `DeclarationArgumentValue` is introduced to support `$`-prefixed context variable references.

- **New `context` generator module** — Emits the `SyncContext` struct when at least one restricted table exists in a sync group (backend only).

- **`InsufficientPermission` error variant** — Added to `UploadTableResponseErrorType`; the client handles it as a no-op stub (with a TODO comment) for now.

- **E2E test schema updated** — Added `#[immutable] created_at` to `user`, introduced a `message` table with `#[immutable] recipient_id`, and split sync groups into `user_only` (no context) and `all_clients` (with `restrict_to` on `message`). All existing tests migrated to the new group names.

### Tests
E2E tests exercising the new behaviour were added:

| Test | Location | What it verifies |
|---|---|---|
| `test_download_only_returns_messages_matching_context` | `happy_paths/download.rs` | Download returns only rows whose `recipient_id` matches the supplied context |
| `test_upload_update_message_matching_context` | `happy_paths/upload.rs` | Uploading an update whose restricted column matches context succeeds |
| `test_upload_insert_message_matching_context` | `happy_paths/upload.rs` | Uploading an insert whose restricted column matches context succeeds |
| `test_upload_insert_message_mismatching_context` | `unhappy_paths/backend.rs` | Insert with wrong context is rejected with `InsufficientPermission` |
| `test_upload_update_message_mismatching_context` | `unhappy_paths/backend.rs` | Update with wrong context is rejected with `InsufficientPermission` |

All existing edge-case and happy-path tests were updated to compile against the renamed sync groups and new `created_at` field.

### Future Work
Client-side handling of `InsufficientPermission` responses is currently a stub (TODO). Proper recovery logic (e.g. re-attempting as an insert, or surfacing the error to the caller) is deferred to keep the scope clear.